### PR TITLE
Add an `UnusableDependencies` incompatibility kind

### DIFF
--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -45,6 +45,8 @@ pub enum Kind<P: Package, VS: VersionSet> {
     NoVersions(P, VS),
     /// Dependencies of the package are unavailable for versions in that range.
     UnavailableDependencies(P, VS),
+    /// Dependencies of the package are unusable for versions in that range.
+    UnusableDependencies(P, VS, Option<String>),
     /// Incompatibility coming from the dependencies of a given package.
     FromDependencyOf(P, VS, P, VS),
     /// Derived from two causes. Stores cause ids.
@@ -101,6 +103,17 @@ impl<P: Package, VS: VersionSet> Incompatibility<P, VS> {
         Self {
             package_terms: SmallMap::One([(package.clone(), Term::Positive(set.clone()))]),
             kind: Kind::UnavailableDependencies(package, set),
+        }
+    }
+
+    /// Create an incompatibility to remember
+    /// that a package version is not selectable
+    /// because its dependencies are not usable.
+    pub fn unusable_dependencies(package: P, version: VS::V, reason: Option<String>) -> Self {
+        let set = VS::singleton(version);
+        Self {
+            package_terms: SmallMap::One([(package.clone(), Term::Positive(set.clone()))]),
+            kind: Kind::UnusableDependencies(package, set, reason),
         }
     }
 
@@ -205,6 +218,9 @@ impl<P: Package, VS: VersionSet> Incompatibility<P, VS> {
             }
             Kind::UnavailableDependencies(package, set) => DerivationTree::External(
                 External::UnavailableDependencies(package.clone(), set.clone()),
+            ),
+            Kind::UnusableDependencies(package, set, reason) => DerivationTree::External(
+                External::UnusableDependencies(package.clone(), set.clone(), reason.clone()),
             ),
             Kind::FromDependencyOf(package, set, dep_package, dep_set) => {
                 DerivationTree::External(External::FromDependencyOf(

--- a/src/range.rs
+++ b/src/range.rs
@@ -117,6 +117,10 @@ impl<V> Range<V> {
             segments: SmallVec::one((Included(v1.into()), Excluded(v2.into()))),
         }
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.segments.is_empty()
+    }
 }
 
 impl<V: Clone> Range<V> {

--- a/src/report.rs
+++ b/src/report.rs
@@ -41,6 +41,8 @@ pub enum External<P: Package, VS: VersionSet> {
     NoVersions(P, VS),
     /// Dependencies of the package are unavailable for versions in that set.
     UnavailableDependencies(P, VS),
+    /// Dependencies of the package are unusable for versions in that set.
+    UnusableDependencies(P, VS, Option<String>),
     /// Incompatibility coming from the dependencies of a given package.
     FromDependencyOf(P, VS, P, VS),
 }
@@ -113,6 +115,13 @@ impl<P: Package, VS: VersionSet> DerivationTree<P, VS> {
             DerivationTree::External(External::UnavailableDependencies(_, r)) => Some(
                 DerivationTree::External(External::UnavailableDependencies(package, set.union(&r))),
             ),
+            DerivationTree::External(External::UnusableDependencies(_, r, reason)) => {
+                Some(DerivationTree::External(External::UnusableDependencies(
+                    package,
+                    set.union(&r),
+                    reason,
+                )))
+            }
             DerivationTree::External(External::FromDependencyOf(p1, r1, p2, r2)) => {
                 if p1 == package {
                     Some(DerivationTree::External(External::FromDependencyOf(
@@ -156,6 +165,29 @@ impl<P: Package, VS: VersionSet> fmt::Display for External<P, VS> {
                         "dependencies of {} at version {} are unavailable",
                         package, set
                     )
+                }
+            }
+            Self::UnusableDependencies(package, set, reason) => {
+                if let Some(reason) = reason {
+                    if set == &VS::full() {
+                        write!(f, "dependencies of {} are unusable: {reason}", package)
+                    } else {
+                        write!(
+                            f,
+                            "dependencies of {} at version {} are unusable: {reason}",
+                            package, set
+                        )
+                    }
+                } else {
+                    if set == &VS::full() {
+                        write!(f, "dependencies of {} are unusable", package)
+                    } else {
+                        write!(
+                            f,
+                            "dependencies of {} at version {} are unusable",
+                            package, set
+                        )
+                    }
                 }
             }
             Self::FromDependencyOf(p, set_p, dep, set_dep) => {


### PR DESCRIPTION
As in https://github.com/pubgrub-rs/pubgrub/pull/153 but with the reason string that I need.

See discussion in the upstream for future plans that will replace this work. In the meantime, I'll make use of this.

Includes `Range.is_empty() -> bool` which I need to detect empty version sets.