### PR TITLE
Perf: Clone only valid segments

### DIFF
--- a/.github/workflows/permaref.yaml
+++ b/.github/workflows/permaref.yaml
@@ -1,0 +1,40 @@
+# Automatically creates a tag for each commit to `main` so when we rebase
+# changes on top of the upstream, we retain permanent references to each
+# previous commit so they are not orphaned and eventually deleted.
+name: Create permanent reference
+
+on:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get the permanent ref number
+        id: get_version
+        run: |
+          # Enable pipefail so git command failures do not result in null versions downstream
+          set -x
+
+          echo ::set-output name=LAST_PERMA_NUMBER::$(\
+            git ls-remote --tags --refs --sort="v:refname" \
+            https://github.com/zanieb/pubgrub.git | grep "tags/perma-" | tail -n1 | sed 's/.*\/perma-//' \
+          )
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Create and push the new tag
+        run: |
+          TAG="perma-$((LAST_PERMA_NUMBER + 1))"
+          git tag -a "$TAG" -m "Automatically created on push to `main`"
+          git push origin "$TAG"
+        env:
+          LAST_PERMA_NUMBER: ${{ steps.get_version.outputs.LAST_PERMA_NUMBER }}

--- a/.github/workflows/permaref.yaml
+++ b/.github/workflows/permaref.yaml
@@ -9,7 +9,7 @@ on:
       - "main"
 
 jobs:
-  release:
+  create-permaref:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -21,10 +21,10 @@ jobs:
           # Enable pipefail so git command failures do not result in null versions downstream
           set -x
 
-          echo ::set-output name=LAST_PERMA_NUMBER::$(\
+          echo "LAST_PERMA_NUMBER=$(\
             git ls-remote --tags --refs --sort="v:refname" \
             https://github.com/zanieb/pubgrub.git | grep "tags/perma-" | tail -n1 | sed 's/.*\/perma-//' \
-          )
+          )" >> $GITHUB_OUTPUT
 
       - name: Configure Git
         run: |
@@ -34,7 +34,7 @@ jobs:
       - name: Create and push the new tag
         run: |
           TAG="perma-$((LAST_PERMA_NUMBER + 1))"
-          git tag -a "$TAG" -m "Automatically created on push to `main`"
+          git tag -a "$TAG" -m 'Automatically created on push to `main`'
           git push origin "$TAG"
         env:
           LAST_PERMA_NUMBER: ${{ steps.get_version.outputs.LAST_PERMA_NUMBER }}

--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -24,7 +24,7 @@ pub struct State<P: Package, VS: VersionSet, Priority: Ord + Clone> {
     root_package: P,
     root_version: VS::V,
 
-    incompatibilities: Map<P, Vec<IncompId<P, VS>>>,
+    pub incompatibilities: Map<P, Vec<IncompId<P, VS>>>,
 
     /// Store the ids of incompatibilities that are already contradicted
     /// and will stay that way until the next conflict and backtrack is operated.

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -45,6 +45,8 @@ pub enum Kind<P: Package, VS: VersionSet> {
     NoVersions(P, VS),
     /// Dependencies of the package are unavailable for versions in that range.
     UnavailableDependencies(P, VS),
+    /// Dependencies of the package are unusable for versions in that range.
+    UnusableDependencies(P, VS, Option<String>),
     /// Incompatibility coming from the dependencies of a given package.
     FromDependencyOf(P, VS, P, VS),
     /// Derived from two causes. Stores cause ids.
@@ -101,6 +103,17 @@ impl<P: Package, VS: VersionSet> Incompatibility<P, VS> {
         Self {
             package_terms: SmallMap::One([(package.clone(), Term::Positive(set.clone()))]),
             kind: Kind::UnavailableDependencies(package, set),
+        }
+    }
+
+    /// Create an incompatibility to remember
+    /// that a package version is not selectable
+    /// because its dependencies are not usable.
+    pub fn unusable_dependencies(package: P, version: VS::V, reason: Option<String>) -> Self {
+        let set = VS::singleton(version);
+        Self {
+            package_terms: SmallMap::One([(package.clone(), Term::Positive(set.clone()))]),
+            kind: Kind::UnusableDependencies(package, set, reason),
         }
     }
 
@@ -205,6 +218,9 @@ impl<P: Package, VS: VersionSet> Incompatibility<P, VS> {
             }
             Kind::UnavailableDependencies(package, set) => DerivationTree::External(
                 External::UnavailableDependencies(package.clone(), set.clone()),
+            ),
+            Kind::UnusableDependencies(package, set, reason) => DerivationTree::External(
+                External::UnusableDependencies(package.clone(), set.clone(), reason.clone()),
             ),
             Kind::FromDependencyOf(package, set, dep_package, dep_set) => {
                 DerivationTree::External(External::FromDependencyOf(

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -31,14 +31,14 @@ use crate::version_set::VersionSet;
 #[derive(Debug, Clone)]
 pub struct Incompatibility<P: Package, VS: VersionSet> {
     package_terms: SmallMap<P, Term<VS>>,
-    kind: Kind<P, VS>,
+    pub kind: Kind<P, VS>,
 }
 
 /// Type alias of unique identifiers for incompatibilities.
 pub type IncompId<P, VS> = Id<Incompatibility<P, VS>>;
 
 #[derive(Debug, Clone)]
-enum Kind<P: Package, VS: VersionSet> {
+pub enum Kind<P: Package, VS: VersionSet> {
     /// Initial incompatibility aiming at picking the root package for the first decision.
     NotRoot(P, VS::V),
     /// There are no versions in the given range for this package.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,8 +217,7 @@
 //! with a cache, you may want to know that some versions
 //! do not exist in your cache.
 
-#![allow(clippy::rc_buffer)]
-#![warn(missing_docs)]
+#![allow(clippy::all, unreachable_pub)]
 
 pub mod error;
 pub mod package;

--- a/src/range.rs
+++ b/src/range.rs
@@ -199,7 +199,7 @@ impl<V: Ord> Range<V> {
                 .segments
                 .last()
                 .expect("if there is a first element, there must be a last element");
-            (bound_as_ref(start), bound_as_ref(&end.1))
+            (start.as_ref(), end.1.as_ref())
         })
     }
 
@@ -268,15 +268,6 @@ impl<V: Ord> Range<V> {
     }
 }
 
-/// Implementation of [`Bound::as_ref`] which is currently marked as unstable.
-fn bound_as_ref<V>(bound: &Bound<V>) -> Bound<&V> {
-    match bound {
-        Included(v) => Included(v),
-        Excluded(v) => Excluded(v),
-        Unbounded => Unbounded,
-    }
-}
-
 fn valid_segment<T: PartialOrd>(start: &Bound<T>, end: &Bound<T>) -> bool {
     match (start, end) {
         (Included(s), Included(e)) => s <= e,
@@ -311,7 +302,7 @@ impl<V: Ord + Clone> Range<V> {
 
                 (Included(i), Excluded(e)) | (Excluded(e), Included(i)) if i <= e => Excluded(e),
                 (Included(i), Excluded(e)) | (Excluded(e), Included(i)) if e < i => Included(i),
-                (s, Unbounded) | (Unbounded, s) => bound_as_ref(s),
+                (s, Unbounded) | (Unbounded, s) => s.as_ref(),
                 _ => unreachable!(),
             }
             .cloned();
@@ -321,7 +312,7 @@ impl<V: Ord + Clone> Range<V> {
 
                 (Included(i), Excluded(e)) | (Excluded(e), Included(i)) if i >= e => Excluded(e),
                 (Included(i), Excluded(e)) | (Excluded(e), Included(i)) if e > i => Included(i),
-                (s, Unbounded) | (Unbounded, s) => bound_as_ref(s),
+                (s, Unbounded) | (Unbounded, s) => s.as_ref(),
                 _ => unreachable!(),
             }
             .cloned();
@@ -377,7 +368,7 @@ impl<V: Display + Eq> Display for Range<V> {
         } else {
             for (idx, segment) in self.segments.iter().enumerate() {
                 if idx > 0 {
-                    write!(f, ", ")?;
+                    write!(f, " | ")?;
                 }
                 match segment {
                     (Unbounded, Unbounded) => write!(f, "*")?,
@@ -388,7 +379,7 @@ impl<V: Display + Eq> Display for Range<V> {
                         if v == b {
                             write!(f, "=={v}")?
                         } else {
-                            write!(f, ">={v},<={b}")?
+                            write!(f, ">={v}, <={b}")?
                         }
                     }
                     (Included(v), Excluded(b)) => write!(f, ">={v}, <{b}")?,

--- a/src/range.rs
+++ b/src/range.rs
@@ -117,6 +117,10 @@ impl<V> Range<V> {
             segments: SmallVec::one((Included(v1.into()), Excluded(v2.into()))),
         }
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.segments.is_empty()
+    }
 }
 
 impl<V: Clone> Range<V> {

--- a/src/report.rs
+++ b/src/report.rs
@@ -41,6 +41,8 @@ pub enum External<P: Package, VS: VersionSet> {
     NoVersions(P, VS),
     /// Dependencies of the package are unavailable for versions in that set.
     UnavailableDependencies(P, VS),
+    /// Dependencies of the package are unusable for versions in that set.
+    UnusableDependencies(P, VS, Option<String>),
     /// Incompatibility coming from the dependencies of a given package.
     FromDependencyOf(P, VS, P, VS),
 }
@@ -113,6 +115,13 @@ impl<P: Package, VS: VersionSet> DerivationTree<P, VS> {
             DerivationTree::External(External::UnavailableDependencies(_, r)) => Some(
                 DerivationTree::External(External::UnavailableDependencies(package, set.union(&r))),
             ),
+            DerivationTree::External(External::UnusableDependencies(_, r, reason)) => {
+                Some(DerivationTree::External(External::UnusableDependencies(
+                    package,
+                    set.union(&r),
+                    reason,
+                )))
+            }
             DerivationTree::External(External::FromDependencyOf(p1, r1, p2, r2)) => {
                 if p1 == package {
                     Some(DerivationTree::External(External::FromDependencyOf(
@@ -156,6 +165,29 @@ impl<P: Package, VS: VersionSet> fmt::Display for External<P, VS> {
                         "dependencies of {} at version {} are unavailable",
                         package, set
                     )
+                }
+            }
+            Self::UnusableDependencies(package, set, reason) => {
+                if let Some(reason) = reason {
+                    if set == &VS::full() {
+                        write!(f, "dependencies of {} are unusable: {reason}", package)
+                    } else {
+                        write!(
+                            f,
+                            "dependencies of {} at version {} are unusable: {reason}",
+                            package, set
+                        )
+                    }
+                } else {
+                    if set == &VS::full() {
+                        write!(f, "dependencies of {} are unusable", package)
+                    } else {
+                        write!(
+                            f,
+                            "dependencies of {} at version {} are unusable",
+                            package, set
+                        )
+                    }
                 }
             }
             Self::FromDependencyOf(p, set_p, dep, set_dep) => {

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -73,8 +73,8 @@ use std::collections::{BTreeMap, BTreeSet as Set};
 use std::error::Error;
 
 use crate::error::PubGrubError;
-use crate::internal::core::State;
-use crate::internal::incompatibility::Incompatibility;
+pub use crate::internal::core::State;
+pub use crate::internal::incompatibility::{Incompatibility, Kind};
 use crate::package::Package;
 use crate::type_aliases::{DependencyConstraints, Map, SelectedDependencies};
 use crate::version_set::VersionSet;

--- a/src/term.rs
+++ b/src/term.rs
@@ -64,7 +64,7 @@ impl<VS: VersionSet> Term<VS> {
 
     /// Unwrap the set contained in a positive term.
     /// Will panic if used on a negative set.
-    pub(crate) fn unwrap_positive(&self) -> &VS {
+    pub fn unwrap_positive(&self) -> &VS {
         match self {
             Self::Positive(set) => set,
             _ => panic!("Negative term cannot unwrap positive set"),


### PR DESCRIPTION
Remove 30% of the runtime which was previously being spent cloning versions that we couldn't use anyway.

flamegraph before:

![image](https://github.com/zanieb/pubgrub/assets/6826232/98bd2911-dce3-4c4e-90dc-9006c83bc37d)

flamegraph after:

![image](https://github.com/zanieb/pubgrub/assets/6826232/39ee3caa-bf83-48cd-91a4-276869ee97a4)

Notice how the `::cloned` section disappears.