### PR TITLE
Simplify version sets in error reports

### DIFF
--- a/examples/holes.rs
+++ b/examples/holes.rs
@@ -1,0 +1,44 @@
+use pubgrub::error::PubGrubError;
+use pubgrub::range::Range;
+use pubgrub::report::{DefaultStringReporter, Reporter};
+use pubgrub::solver::{resolve, OfflineDependencyProvider};
+use pubgrub::version::SemanticVersion;
+use rustc_hash::FxHashMap;
+
+fn main() {
+    let mut dependency_provider = OfflineDependencyProvider::<&str, Range<SemanticVersion>>::new();
+
+    // root depends on foo...
+    dependency_provider.add_dependencies("root", (1, 0, 0), vec![("foo", Range::full())]);
+
+    for i in 1..5 {
+        // foo depends on bar...
+        dependency_provider.add_dependencies("foo", (i, 0, 0), vec![("bar", Range::full())]);
+    }
+
+    let mut versions = FxHashMap::default();
+    for package in dependency_provider.packages() {
+        versions.insert(
+            *package,
+            dependency_provider
+                .versions(package)
+                .expect("Package must have versions")
+                .cloned()
+                .collect::<Vec<_>>(),
+        );
+    }
+
+    match resolve(&dependency_provider, "root", (1, 0, 0)) {
+        Ok(sol) => println!("{:?}", sol),
+        Err(PubGrubError::NoSolution(derivation_tree)) => {
+            let simple_deriviation_tree = derivation_tree.simplify_versions(&versions);
+            eprintln!("{}", DefaultStringReporter::report(&derivation_tree));
+            eprintln!("\n----------\n");
+            eprintln!(
+                "{}",
+                DefaultStringReporter::report(&simple_deriviation_tree)
+            );
+        }
+        Err(err) => panic!("{:?}", err),
+    };
+}

--- a/src/report.rs
+++ b/src/report.rs
@@ -190,14 +190,14 @@ impl<P: Package, VS: VersionSet> fmt::Display for External<P, VS> {
                 write!(f, "we are solving dependencies of {} {}", package, version)
             }
             Self::NoVersions(package, set) => {
-                if set == &VS::full() {
+                if set == &VS::full() || set == &VS::empty() {
                     write!(f, "there is no available version for {}", package)
                 } else {
                     write!(f, "there is no version of {} in {}", package, set)
                 }
             }
             Self::UnavailableDependencies(package, set) => {
-                if set == &VS::full() {
+                if set == &VS::full() || set == &VS::empty() {
                     write!(f, "dependencies of {} are unavailable", package)
                 } else {
                     write!(
@@ -208,11 +208,13 @@ impl<P: Package, VS: VersionSet> fmt::Display for External<P, VS> {
                 }
             }
             Self::FromDependencyOf(p, set_p, dep, set_dep) => {
-                if set_p == &VS::full() && set_dep == &VS::full() {
+                if (set_p == &VS::full() || set_p == &VS::empty())
+                    && (set_dep == &VS::full() || set_dep == &VS::empty())
+                {
                     write!(f, "{} depends on {}", p, dep)
-                } else if set_p == &VS::full() {
+                } else if set_p == &VS::full() || set_p == &VS::empty() {
                     write!(f, "{} depends on {} {}", p, dep, set_dep)
-                } else if set_dep == &VS::full() {
+                } else if set_dep == &VS::full() || set_dep == &VS::empty() {
                     write!(f, "{} {} depends on {}", p, set_p, dep)
                 } else {
                     write!(f, "{} {} depends on {} {}", p, set_p, dep, set_dep)

--- a/src/report.rs
+++ b/src/report.rs
@@ -164,7 +164,17 @@ impl<P: Package, VS: VersionSet> DerivationTree<P, VS> {
                 DerivationTree::External(external)
             }
             DerivationTree::Derived(derived) => DerivationTree::Derived(Derived {
-                terms: derived.terms.clone(),
+                terms: derived
+                    .terms
+                    .iter()
+                    .map(|(p, t)| {
+                        (
+                            p.clone(),
+                            t.simplify(versions.get(&p).unwrap_or(&Vec::new()).into_iter()),
+                        )
+                    })
+                    .collect(),
+
                 shared_id: derived.shared_id,
                 cause1: Box::new(derived.cause1.simplify_versions(versions)),
                 cause2: Box::new(derived.cause2.simplify_versions(versions)),

--- a/src/term.rs
+++ b/src/term.rs
@@ -101,6 +101,17 @@ impl<VS: VersionSet> Term<VS> {
     pub(crate) fn subset_of(&self, other: &Self) -> bool {
         self == &self.intersection(other)
     }
+
+    pub(crate) fn simplify<'s, I>(&'s self, versions: I) -> Self
+    where
+        I: Iterator<Item = &'s VS::V> + 's,
+        VS::V: 's,
+    {
+        match self {
+            Self::Positive(set) => Self::Positive(set.simplify(versions)),
+            Self::Negative(set) => Self::Negative(set.simplify(versions)),
+        }
+    }
 }
 
 /// Describe a relation between a set of terms S and another term t.

--- a/src/version_set.rs
+++ b/src/version_set.rs
@@ -37,6 +37,11 @@ pub trait VersionSet: Debug + Display + Clone + Eq {
     /// Compute the intersection with another set.
     fn intersection(&self, other: &Self) -> Self;
 
+    fn simplify<'s, I>(&'s self, versions: I) -> Self
+    where
+        I: Iterator<Item = &'s Self::V> + 's,
+        Self::V: 's;
+
     // Membership
     /// Evaluate membership of a version in this set.
     fn contains(&self, v: &Self::V) -> bool;

--- a/src/version_set.rs
+++ b/src/version_set.rs
@@ -37,6 +37,7 @@ pub trait VersionSet: Debug + Display + Clone + Eq {
     /// Compute the intersection with another set.
     fn intersection(&self, other: &Self) -> Self;
 
+    /// Return a simplified version set, collapsing redundancies.
     fn simplify<'s, I>(&'s self, versions: I) -> Self
     where
         I: Iterator<Item = &'s Self::V> + 's,


### PR DESCRIPTION
Uses https://github.com/pubgrub-rs/pubgrub/pull/156 to allow the default error reporter's messages to be simplified.