### PR TITLE
Simplify version sets in error reports

### DIFF
--- a/.github/workflows/permaref.yaml
+++ b/.github/workflows/permaref.yaml
@@ -1,0 +1,40 @@
+# Automatically creates a tag for each commit to `main` so when we rebase
+# changes on top of the upstream, we retain permanent references to each
+# previous commit so they are not orphaned and eventually deleted.
+name: Create permanent reference
+
+on:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get the permanent ref number
+        id: get_version
+        run: |
+          # Enable pipefail so git command failures do not result in null versions downstream
+          set -x
+
+          echo ::set-output name=LAST_PERMA_NUMBER::$(\
+            git ls-remote --tags --refs --sort="v:refname" \
+            https://github.com/zanieb/pubgrub.git | grep "tags/perma-" | tail -n1 | sed 's/.*\/perma-//' \
+          )
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Create and push the new tag
+        run: |
+          TAG="perma-$((LAST_PERMA_NUMBER + 1))"
+          git tag -a "$TAG" -m "Automatically created on push to `main`"
+          git push origin "$TAG"
+        env:
+          LAST_PERMA_NUMBER: ${{ steps.get_version.outputs.LAST_PERMA_NUMBER }}

--- a/.github/workflows/permaref.yaml
+++ b/.github/workflows/permaref.yaml
@@ -9,7 +9,7 @@ on:
       - "main"
 
 jobs:
-  release:
+  create-permaref:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -21,10 +21,10 @@ jobs:
           # Enable pipefail so git command failures do not result in null versions downstream
           set -x
 
-          echo ::set-output name=LAST_PERMA_NUMBER::$(\
+          echo "LAST_PERMA_NUMBER=$(\
             git ls-remote --tags --refs --sort="v:refname" \
             https://github.com/zanieb/pubgrub.git | grep "tags/perma-" | tail -n1 | sed 's/.*\/perma-//' \
-          )
+          )" >> $GITHUB_OUTPUT
 
       - name: Configure Git
         run: |
@@ -34,7 +34,7 @@ jobs:
       - name: Create and push the new tag
         run: |
           TAG="perma-$((LAST_PERMA_NUMBER + 1))"
-          git tag -a "$TAG" -m "Automatically created on push to `main`"
+          git tag -a "$TAG" -m 'Automatically created on push to `main`'
           git push origin "$TAG"
         env:
           LAST_PERMA_NUMBER: ${{ steps.get_version.outputs.LAST_PERMA_NUMBER }}

--- a/examples/holes.rs
+++ b/examples/holes.rs
@@ -1,0 +1,44 @@
+use pubgrub::error::PubGrubError;
+use pubgrub::range::Range;
+use pubgrub::report::{DefaultStringReporter, Reporter};
+use pubgrub::solver::{resolve, OfflineDependencyProvider};
+use pubgrub::version::SemanticVersion;
+use rustc_hash::FxHashMap;
+
+fn main() {
+    let mut dependency_provider = OfflineDependencyProvider::<&str, Range<SemanticVersion>>::new();
+
+    // root depends on foo...
+    dependency_provider.add_dependencies("root", (1, 0, 0), vec![("foo", Range::full())]);
+
+    for i in 1..5 {
+        // foo depends on bar...
+        dependency_provider.add_dependencies("foo", (i, 0, 0), vec![("bar", Range::full())]);
+    }
+
+    let mut versions = FxHashMap::default();
+    for package in dependency_provider.packages() {
+        versions.insert(
+            *package,
+            dependency_provider
+                .versions(package)
+                .expect("Package must have versions")
+                .cloned()
+                .collect::<Vec<_>>(),
+        );
+    }
+
+    match resolve(&dependency_provider, "root", (1, 0, 0)) {
+        Ok(sol) => println!("{:?}", sol),
+        Err(PubGrubError::NoSolution(derivation_tree)) => {
+            let simple_deriviation_tree = derivation_tree.simplify_versions(&versions);
+            eprintln!("{}", DefaultStringReporter::report(&derivation_tree));
+            eprintln!("\n----------\n");
+            eprintln!(
+                "{}",
+                DefaultStringReporter::report(&simple_deriviation_tree)
+            );
+        }
+        Err(err) => panic!("{:?}", err),
+    };
+}

--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -24,7 +24,7 @@ pub struct State<P: Package, VS: VersionSet, Priority: Ord + Clone> {
     root_package: P,
     root_version: VS::V,
 
-    incompatibilities: Map<P, Vec<IncompId<P, VS>>>,
+    pub incompatibilities: Map<P, Vec<IncompId<P, VS>>>,
 
     /// Store the ids of incompatibilities that are already contradicted
     /// and will stay that way until the next conflict and backtrack is operated.

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -45,6 +45,8 @@ pub enum Kind<P: Package, VS: VersionSet> {
     NoVersions(P, VS),
     /// Dependencies of the package are unavailable for versions in that range.
     UnavailableDependencies(P, VS),
+    /// Dependencies of the package are unusable for versions in that range.
+    UnusableDependencies(P, VS, Option<String>),
     /// Incompatibility coming from the dependencies of a given package.
     FromDependencyOf(P, VS, P, VS),
     /// Derived from two causes. Stores cause ids.
@@ -101,6 +103,17 @@ impl<P: Package, VS: VersionSet> Incompatibility<P, VS> {
         Self {
             package_terms: SmallMap::One([(package.clone(), Term::Positive(set.clone()))]),
             kind: Kind::UnavailableDependencies(package, set),
+        }
+    }
+
+    /// Create an incompatibility to remember
+    /// that a package version is not selectable
+    /// because its dependencies are not usable.
+    pub fn unusable_dependencies(package: P, version: VS::V, reason: Option<String>) -> Self {
+        let set = VS::singleton(version);
+        Self {
+            package_terms: SmallMap::One([(package.clone(), Term::Positive(set.clone()))]),
+            kind: Kind::UnusableDependencies(package, set, reason),
         }
     }
 
@@ -205,6 +218,9 @@ impl<P: Package, VS: VersionSet> Incompatibility<P, VS> {
             }
             Kind::UnavailableDependencies(package, set) => DerivationTree::External(
                 External::UnavailableDependencies(package.clone(), set.clone()),
+            ),
+            Kind::UnusableDependencies(package, set, reason) => DerivationTree::External(
+                External::UnusableDependencies(package.clone(), set.clone(), reason.clone()),
             ),
             Kind::FromDependencyOf(package, set, dep_package, dep_set) => {
                 DerivationTree::External(External::FromDependencyOf(

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -31,14 +31,14 @@ use crate::version_set::VersionSet;
 #[derive(Debug, Clone)]
 pub struct Incompatibility<P: Package, VS: VersionSet> {
     package_terms: SmallMap<P, Term<VS>>,
-    kind: Kind<P, VS>,
+    pub kind: Kind<P, VS>,
 }
 
 /// Type alias of unique identifiers for incompatibilities.
 pub type IncompId<P, VS> = Id<Incompatibility<P, VS>>;
 
 #[derive(Debug, Clone)]
-enum Kind<P: Package, VS: VersionSet> {
+pub enum Kind<P: Package, VS: VersionSet> {
     /// Initial incompatibility aiming at picking the root package for the first decision.
     NotRoot(P, VS::V),
     /// There are no versions in the given range for this package.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -217,8 +217,7 @@
 //! with a cache, you may want to know that some versions
 //! do not exist in your cache.
 
-#![allow(clippy::rc_buffer)]
-#![warn(missing_docs)]
+#![allow(clippy::all, unreachable_pub)]
 
 pub mod error;
 pub mod package;

--- a/src/range.rs
+++ b/src/range.rs
@@ -200,7 +200,7 @@ impl<V: Ord> Range<V> {
                 .segments
                 .last()
                 .expect("if there is a first element, there must be a last element");
-            (bound_as_ref(start), bound_as_ref(&end.1))
+            (start.as_ref(), end.1.as_ref())
         })
     }
 
@@ -303,15 +303,6 @@ fn within_bounds<V: PartialOrd>(v: &V, segment: &Interval<V>) -> Ordering {
     Ordering::Greater
 }
 
-/// Implementation of [`Bound::as_ref`] which is currently marked as unstable.
-fn bound_as_ref<V>(bound: &Bound<V>) -> Bound<&V> {
-    match bound {
-        Included(v) => Included(v),
-        Excluded(v) => Excluded(v),
-        Unbounded => Unbounded,
-    }
-}
-
 fn valid_segment<T: PartialOrd>(start: &Bound<T>, end: &Bound<T>) -> bool {
     match (start, end) {
         (Included(s), Included(e)) => s <= e,
@@ -376,7 +367,7 @@ impl<V: Ord + Clone> Range<V> {
 
                 (Included(i), Excluded(e)) | (Excluded(e), Included(i)) if i <= e => Excluded(e),
                 (Included(i), Excluded(e)) | (Excluded(e), Included(i)) if e < i => Included(i),
-                (s, Unbounded) | (Unbounded, s) => bound_as_ref(s),
+                (s, Unbounded) | (Unbounded, s) => s.as_ref(),
                 _ => unreachable!(),
             }
             .cloned();
@@ -386,7 +377,7 @@ impl<V: Ord + Clone> Range<V> {
 
                 (Included(i), Excluded(e)) | (Excluded(e), Included(i)) if i >= e => Excluded(e),
                 (Included(i), Excluded(e)) | (Excluded(e), Included(i)) if e > i => Included(i),
-                (s, Unbounded) | (Unbounded, s) => bound_as_ref(s),
+                (s, Unbounded) | (Unbounded, s) => s.as_ref(),
                 _ => unreachable!(),
             }
             .cloned();
@@ -490,7 +481,7 @@ impl<V: Display + Eq> Display for Range<V> {
         } else {
             for (idx, segment) in self.segments.iter().enumerate() {
                 if idx > 0 {
-                    write!(f, ", ")?;
+                    write!(f, " | ")?;
                 }
                 match segment {
                     (Unbounded, Unbounded) => write!(f, "*")?,
@@ -501,7 +492,7 @@ impl<V: Display + Eq> Display for Range<V> {
                         if v == b {
                             write!(f, "=={v}")?
                         } else {
-                            write!(f, ">={v},<={b}")?
+                            write!(f, ">={v}, <={b}")?
                         }
                     }
                     (Included(v), Excluded(b)) => write!(f, ">={v}, <{b}")?,

--- a/src/range.rs
+++ b/src/range.rs
@@ -118,6 +118,10 @@ impl<V> Range<V> {
             segments: SmallVec::one((Included(v1.into()), Excluded(v2.into()))),
         }
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.segments.is_empty()
+    }
 }
 
 impl<V: Clone> Range<V> {

--- a/src/range.rs
+++ b/src/range.rs
@@ -391,36 +391,6 @@ impl<V: Ord + Clone> Range<V> {
         Self { segments }.check_invariants()
     }
 
-    /// Returns a simpler Range that contains the same versions
-    ///
-    /// For every one of the Versions provided in versions the existing range and
-    /// the simplified range will agree on whether it is contained.
-    /// The simplified version may include or exclude versions that are not in versions as the implementation wishes.
-    /// For example:
-    ///  - If all the versions are contained in the original than the range will be simplified to `full`.
-    ///  - If none of the versions are contained in the original than the range will be simplified to `empty`.
-    ///
-    /// If versions are not sorted the correctness of this function is not guaranteed.
-    pub fn simplify<'v, I>(&self, versions: I) -> Self
-    where
-        I: Iterator<Item = &'v V> + 'v,
-        V: 'v,
-    {
-        // Return the segment index in the range for each version in the range, None otherwise
-        let version_locations = versions.scan(0, move |i, v| {
-            while let Some(segment) = self.segments.get(*i) {
-                match within_bounds(v, segment) {
-                    Ordering::Less => return Some(None),
-                    Ordering::Equal => return Some(Some(*i)),
-                    Ordering::Greater => *i += 1,
-                }
-            }
-            Some(None)
-        });
-        let kept_segments = group_adjacent_locations(version_locations);
-        self.keep_segments(kept_segments)
-    }
-
     /// Create a new range with a subset of segments at given location bounds.
     ///
     /// Each new segment is constructed from a pair of segments, taking the
@@ -469,6 +439,36 @@ impl<T: Debug + Display + Clone + Eq + Ord> VersionSet for Range<T> {
 
     fn union(&self, other: &Self) -> Self {
         Range::union(self, other)
+    }
+
+    /// Returns a simpler Range that contains the same versions
+    ///
+    /// For every one of the Versions provided in versions the existing range and
+    /// the simplified range will agree on whether it is contained.
+    /// The simplified version may include or exclude versions that are not in versions as the implementation wishes.
+    /// For example:
+    ///  - If all the versions are contained in the original than the range will be simplified to `full`.
+    ///  - If none of the versions are contained in the original than the range will be simplified to `empty`.
+    ///
+    /// If versions are not sorted the correctness of this function is not guaranteed.
+    fn simplify<'s, I>(&self, versions: I) -> Self
+    where
+        I: Iterator<Item = &'s Self::V> + 's,
+        Self::V: 's,
+    {
+        // Return the segment index in the range for each version in the range, None otherwise
+        let version_locations = versions.scan(0, move |i, v| {
+            while let Some(segment) = self.segments.get(*i) {
+                match within_bounds(v, segment) {
+                    Ordering::Less => return Some(None),
+                    Ordering::Equal => return Some(Some(*i)),
+                    Ordering::Greater => *i += 1,
+                }
+            }
+            Some(None)
+        });
+        let kept_segments = group_adjacent_locations(version_locations);
+        self.keep_segments(kept_segments)
     }
 }
 

--- a/src/report.rs
+++ b/src/report.rs
@@ -41,6 +41,8 @@ pub enum External<P: Package, VS: VersionSet> {
     NoVersions(P, VS),
     /// Dependencies of the package are unavailable for versions in that set.
     UnavailableDependencies(P, VS),
+    /// Dependencies of the package are unusable for versions in that set.
+    UnusableDependencies(P, VS, Option<String>),
     /// Incompatibility coming from the dependencies of a given package.
     FromDependencyOf(P, VS, P, VS),
 }
@@ -113,6 +115,13 @@ impl<P: Package, VS: VersionSet> DerivationTree<P, VS> {
             DerivationTree::External(External::UnavailableDependencies(_, r)) => Some(
                 DerivationTree::External(External::UnavailableDependencies(package, set.union(&r))),
             ),
+            DerivationTree::External(External::UnusableDependencies(_, r, reason)) => {
+                Some(DerivationTree::External(External::UnusableDependencies(
+                    package,
+                    set.union(&r),
+                    reason,
+                )))
+            }
             DerivationTree::External(External::FromDependencyOf(p1, r1, p2, r2)) => {
                 if p1 == package {
                     Some(DerivationTree::External(External::FromDependencyOf(
@@ -156,6 +165,29 @@ impl<P: Package, VS: VersionSet> fmt::Display for External<P, VS> {
                         "dependencies of {} at version {} are unavailable",
                         package, set
                     )
+                }
+            }
+            Self::UnusableDependencies(package, set, reason) => {
+                if let Some(reason) = reason {
+                    if set == &VS::full() {
+                        write!(f, "dependencies of {} are unusable: {reason}", package)
+                    } else {
+                        write!(
+                            f,
+                            "dependencies of {} at version {} are unusable: {reason}",
+                            package, set
+                        )
+                    }
+                } else {
+                    if set == &VS::full() {
+                        write!(f, "dependencies of {} are unusable", package)
+                    } else {
+                        write!(
+                            f,
+                            "dependencies of {} at version {} are unusable",
+                            package, set
+                        )
+                    }
                 }
             }
             Self::FromDependencyOf(p, set_p, dep, set_dep) => {

--- a/src/report.rs
+++ b/src/report.rs
@@ -173,7 +173,17 @@ impl<P: Package, VS: VersionSet> DerivationTree<P, VS> {
                 DerivationTree::External(external)
             }
             DerivationTree::Derived(derived) => DerivationTree::Derived(Derived {
-                terms: derived.terms.clone(),
+                terms: derived
+                    .terms
+                    .iter()
+                    .map(|(p, t)| {
+                        (
+                            p.clone(),
+                            t.simplify(versions.get(&p).unwrap_or(&Vec::new()).into_iter()),
+                        )
+                    })
+                    .collect(),
+
                 shared_id: derived.shared_id,
                 cause1: Box::new(derived.cause1.simplify_versions(versions)),
                 cause2: Box::new(derived.cause2.simplify_versions(versions)),

--- a/src/report.rs
+++ b/src/report.rs
@@ -169,6 +169,14 @@ impl<P: Package, VS: VersionSet> DerivationTree<P, VS> {
                         vs.clone()
                             .simplify(versions.get(&p).unwrap_or(&Vec::new()).into_iter()),
                     ),
+                    External::UnusableDependencies(p, vs, reason) => {
+                        External::UnusableDependencies(
+                            p.clone(),
+                            vs.clone()
+                                .simplify(versions.get(&p).unwrap_or(&Vec::new()).into_iter()),
+                            reason.clone(),
+                        )
+                    }
                 };
                 DerivationTree::External(external)
             }

--- a/src/report.rs
+++ b/src/report.rs
@@ -199,14 +199,14 @@ impl<P: Package, VS: VersionSet> fmt::Display for External<P, VS> {
                 write!(f, "we are solving dependencies of {} {}", package, version)
             }
             Self::NoVersions(package, set) => {
-                if set == &VS::full() {
+                if set == &VS::full() || set == &VS::empty() {
                     write!(f, "there is no available version for {}", package)
                 } else {
                     write!(f, "there is no version of {} in {}", package, set)
                 }
             }
             Self::UnavailableDependencies(package, set) => {
-                if set == &VS::full() {
+                if set == &VS::full() || set == &VS::empty() {
                     write!(f, "dependencies of {} are unavailable", package)
                 } else {
                     write!(
@@ -240,11 +240,13 @@ impl<P: Package, VS: VersionSet> fmt::Display for External<P, VS> {
                 }
             }
             Self::FromDependencyOf(p, set_p, dep, set_dep) => {
-                if set_p == &VS::full() && set_dep == &VS::full() {
+                if (set_p == &VS::full() || set_p == &VS::empty())
+                    && (set_dep == &VS::full() || set_dep == &VS::empty())
+                {
                     write!(f, "{} depends on {}", p, dep)
-                } else if set_p == &VS::full() {
+                } else if set_p == &VS::full() || set_p == &VS::empty() {
                     write!(f, "{} depends on {} {}", p, dep, set_dep)
-                } else if set_dep == &VS::full() {
+                } else if set_dep == &VS::full() || set_dep == &VS::empty() {
                     write!(f, "{} {} depends on {}", p, set_p, dep)
                 } else {
                     write!(f, "{} {} depends on {} {}", p, set_p, dep, set_dep)

--- a/src/report.rs
+++ b/src/report.rs
@@ -6,6 +6,8 @@
 use std::fmt;
 use std::ops::{Deref, DerefMut};
 
+use rustc_hash::FxHashMap;
+
 use crate::package::Package;
 use crate::term::Term;
 use crate::type_aliases::Map;
@@ -139,6 +141,43 @@ impl<P: Package, VS: VersionSet> DerivationTree<P, VS> {
                     )))
                 }
             }
+        }
+    }
+
+    /// Simplify version ranges in the deriviation tree using the available
+    /// versions for each package.
+    pub fn simplify_versions(&self, versions: &FxHashMap<P, Vec<VS::V>>) -> Self {
+        match self {
+            DerivationTree::External(external) => {
+                let external = match external {
+                    External::NotRoot(..) => external.clone(),
+                    External::FromDependencyOf(l_p, l_vs, r_p, r_vs) => External::FromDependencyOf(
+                        l_p.clone(),
+                        l_vs.clone()
+                            .simplify(versions.get(&l_p).unwrap_or(&Vec::new()).into_iter()),
+                        r_p.clone(),
+                        r_vs.clone()
+                            .simplify(versions.get(&r_p).unwrap_or(&Vec::new()).into_iter()),
+                    ),
+                    External::NoVersions(p, vs) => External::NoVersions(
+                        p.clone(),
+                        vs.clone()
+                            .simplify(versions.get(&p).unwrap_or(&Vec::new()).into_iter()),
+                    ),
+                    External::UnavailableDependencies(p, vs) => External::UnavailableDependencies(
+                        p.clone(),
+                        vs.clone()
+                            .simplify(versions.get(&p).unwrap_or(&Vec::new()).into_iter()),
+                    ),
+                };
+                DerivationTree::External(external)
+            }
+            DerivationTree::Derived(derived) => DerivationTree::Derived(Derived {
+                terms: derived.terms.clone(),
+                shared_id: derived.shared_id,
+                cause1: Box::new(derived.cause1.simplify_versions(versions)),
+                cause2: Box::new(derived.cause2.simplify_versions(versions)),
+            }),
         }
     }
 }

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -73,8 +73,8 @@ use std::collections::{BTreeMap, BTreeSet as Set};
 use std::error::Error;
 
 use crate::error::PubGrubError;
-use crate::internal::core::State;
-use crate::internal::incompatibility::Incompatibility;
+pub use crate::internal::core::State;
+pub use crate::internal::incompatibility::{Incompatibility, Kind};
 use crate::package::Package;
 use crate::type_aliases::{DependencyConstraints, Map, SelectedDependencies};
 use crate::version_set::VersionSet;

--- a/src/term.rs
+++ b/src/term.rs
@@ -64,7 +64,7 @@ impl<VS: VersionSet> Term<VS> {
 
     /// Unwrap the set contained in a positive term.
     /// Will panic if used on a negative set.
-    pub(crate) fn unwrap_positive(&self) -> &VS {
+    pub fn unwrap_positive(&self) -> &VS {
         match self {
             Self::Positive(set) => set,
             _ => panic!("Negative term cannot unwrap positive set"),

--- a/src/term.rs
+++ b/src/term.rs
@@ -101,6 +101,17 @@ impl<VS: VersionSet> Term<VS> {
     pub(crate) fn subset_of(&self, other: &Self) -> bool {
         self == &self.intersection(other)
     }
+
+    pub(crate) fn simplify<'s, I>(&'s self, versions: I) -> Self
+    where
+        I: Iterator<Item = &'s VS::V> + 's,
+        VS::V: 's,
+    {
+        match self {
+            Self::Positive(set) => Self::Positive(set.simplify(versions)),
+            Self::Negative(set) => Self::Negative(set.simplify(versions)),
+        }
+    }
 }
 
 /// Describe a relation between a set of terms S and another term t.

--- a/src/version_set.rs
+++ b/src/version_set.rs
@@ -37,6 +37,11 @@ pub trait VersionSet: Debug + Display + Clone + Eq {
     /// Compute the intersection with another set.
     fn intersection(&self, other: &Self) -> Self;
 
+    fn simplify<'s, I>(&'s self, versions: I) -> Self
+    where
+        I: Iterator<Item = &'s Self::V> + 's,
+        Self::V: 's;
+
     // Membership
     /// Evaluate membership of a version in this set.
     fn contains(&self, v: &Self::V) -> bool;

--- a/src/version_set.rs
+++ b/src/version_set.rs
@@ -37,6 +37,7 @@ pub trait VersionSet: Debug + Display + Clone + Eq {
     /// Compute the intersection with another set.
     fn intersection(&self, other: &Self) -> Self;
 
+    /// Return a simplified version set, collapsing redundancies.
     fn simplify<'s, I>(&'s self, versions: I) -> Self
     where
         I: Iterator<Item = &'s Self::V> + 's,


### PR DESCRIPTION
Uses https://github.com/pubgrub-rs/pubgrub/pull/156 to allow the default error reporter's messages to be simplified.