### PR TITLE
Add `DerivationTree.packages() -> HashSet<&P>`

### DIFF
--- a/examples/unsat_root_message_no_version.rs
+++ b/examples/unsat_root_message_no_version.rs
@@ -80,6 +80,13 @@ impl ReportFormatter<Package, Range<SemanticVersion>> for CustomReportFormatter 
                     format!("dependencies of {package} at version {set} are unavailable")
                 }
             }
+            External::UnusableDependencies(package, set, ..) => {
+                if set == &Range::full() {
+                    format!("dependencies of {package} are unusable")
+                } else {
+                    format!("dependencies of {package} at version {set} are unusable")
+                }
+            }
             External::FromDependencyOf(package, package_set, dependency, dependency_set) => {
                 if package_set == &Range::full() && dependency_set == &Range::full() {
                     format!("{package} depends on {dependency}")

--- a/src/report.rs
+++ b/src/report.rs
@@ -3,9 +3,10 @@
 //! Build a report as clear as possible as to why
 //! dependency solving failed.
 
-use std::collections::HashSet;
 use std::fmt;
 use std::ops::{Deref, DerefMut};
+
+use rustc_hash::FxHashSet;
 
 use crate::package::Package;
 use crate::term::Term;
@@ -74,8 +75,8 @@ pub struct Derived<P: Package, VS: VersionSet> {
 
 impl<P: Package, VS: VersionSet> DerivationTree<P, VS> {
     /// Get all [Package]s referred to in the deriviation tree.
-    pub fn packages(&self) -> HashSet<&P> {
-        let mut packages = HashSet::default();
+    pub fn packages(&self) -> FxHashSet<&P> {
+        let mut packages = FxHashSet::default();
         match self {
             Self::External(external) => match external {
                 External::FromDependencyOf(p, _, p2, _) => {

--- a/src/report.rs
+++ b/src/report.rs
@@ -3,6 +3,7 @@
 //! Build a report as clear as possible as to why
 //! dependency solving failed.
 
+use std::collections::HashSet;
 use std::fmt;
 use std::ops::{Deref, DerefMut};
 
@@ -72,6 +73,31 @@ pub struct Derived<P: Package, VS: VersionSet> {
 }
 
 impl<P: Package, VS: VersionSet> DerivationTree<P, VS> {
+    /// Get all [Package]s referred to in the deriviation tree.
+    pub fn packages(&self) -> HashSet<&P> {
+        let mut packages = HashSet::default();
+        match self {
+            Self::External(external) => match external {
+                External::FromDependencyOf(p, _, p2, _) => {
+                    packages.insert(p);
+                    packages.insert(p2);
+                }
+                External::NoVersions(p, _)
+                | External::NotRoot(p, _)
+                | External::UnavailableDependencies(p, _)
+                | External::UnusableDependencies(p, ..) => {
+                    packages.insert(p);
+                }
+            },
+            Self::Derived(derived) => {
+                packages.extend(derived.terms.keys());
+                packages.extend(derived.cause1.packages().iter());
+                packages.extend(derived.cause2.packages().iter());
+            }
+        }
+        packages
+    }
+
     /// Merge the [NoVersions](External::NoVersions) external incompatibilities
     /// with the other one they are matched with
     /// in a derived incompatibility.


### PR DESCRIPTION
Adds a utility to retrieve the package names for efficient lookup of versions for `simplify`