### PR TITLE
Add a public `Range.iter()` method

### DIFF
--- a/src/range.rs
+++ b/src/range.rs
@@ -510,6 +510,11 @@ impl<V: Ord + Clone> Range<V> {
             _ => None,
         }
     }
+
+    /// Iterate over the parts of the range.
+    pub fn iter(&self) -> impl Iterator<Item = &(Bound<V>, Bound<V>)> {
+        self.segments.iter()
+    }
 }
 
 impl<T: Debug + Display + Clone + Eq + Ord> VersionSet for Range<T> {


### PR DESCRIPTION
Otherwise, it's not possible to implement custom formatting of `Range` types.

This generally seems useful. `segments` being fully private was painful.