### PR TITLE
range: make 'as_singleton' return a borrow

### DIFF
--- a/src/range.rs
+++ b/src/range.rs
@@ -207,6 +207,21 @@ impl<V: Clone> Range<V> {
 }
 
 impl<V: Ord> Range<V> {
+    /// If the range includes a single version, return it.
+    /// Otherwise, returns [None].
+    pub fn as_singleton(&self) -> Option<&V> {
+        match self.segments.as_slice() {
+            [(Included(v1), Included(v2))] => {
+                if v1 == v2 {
+                    Some(v1)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
     /// Convert to something that can be used with
     /// [BTreeMap::range](std::collections::BTreeMap::range).
     /// All versions contained in self, will be in the output,
@@ -454,7 +469,7 @@ impl<V: Ord + Clone> Range<V> {
     {
         // Do not simplify singletons
         if let Some(version) = self.as_singleton() {
-            return Self::singleton(version);
+            return Self::singleton(version.clone());
         }
 
         // Return the segment index in the range for each version in the range, None otherwise
@@ -494,21 +509,6 @@ impl<V: Ord + Clone> Range<V> {
             ));
         }
         Self { segments }.check_invariants()
-    }
-
-    /// If the range includes a single version, return it.
-    /// Otherwise, returns [None].
-    pub fn as_singleton(&self) -> Option<V> {
-        match self.segments.as_slice() {
-            [(Included(v1), Included(v2))] => {
-                if v1 == v2 {
-                    Some(v1.clone())
-                } else {
-                    None
-                }
-            }
-            _ => None,
-        }
     }
 
     /// Iterate over the parts of the range.


### PR DESCRIPTION
It's cheaper this way if the caller only needs a `&V`. If the caller
needs a `V`, then they can clone it.

We can also move it to an impl block that only requires `Ord`, so that
it will work with `V` types that don't implement `Clone`.
