### PR TITLE
Update priority queue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ include = ["Cargo.toml", "LICENSE", "README.md", "src/**", "tests/**", "examples
 
 [dependencies]
 indexmap = "2.0.2"
-priority-queue = "1.1.1"
+priority-queue = "2.0.2"
 thiserror = "1.0"
 rustc-hash = "1.1.0"
 serde = { version = "1.0", features = ["derive"], optional = true }


### PR DESCRIPTION
I've been looking at duplicate dependencies and priority-queue 1 was pulling in old versions of indexmap and hashbrown