### PR TITLE
Add `State::add_incompatibility_from_dependencies`

### DIFF
--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -74,6 +74,26 @@ impl<DP: DependencyProvider> State<DP> {
         }
     }
 
+    /// Add the dependencies for the current version of the current package as incompatibilities.
+    pub fn add_package_version_dependencies(
+        &mut self,
+        package: DP::P,
+        version: DP::V,
+        dependencies: impl IntoIterator<Item = (DP::P, DP::VS)>,
+    ) {
+        let dep_incompats = self.add_incompatibility_from_dependencies(
+            package.clone(),
+            version.clone(),
+            dependencies,
+        );
+        self.partial_solution.add_package_version_incompatibilities(
+            package.clone(),
+            version.clone(),
+            dep_incompats,
+            &self.incompatibility_store,
+        )
+    }
+
     /// Add an incompatibility to the state.
     pub fn add_incompatibility(&mut self, incompat: Incompatibility<DP::P, DP::VS, DP::M>) {
         let id = self.incompatibility_store.alloc(incompat);

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -370,7 +370,7 @@ impl<DP: DependencyProvider> PartialSolution<DP> {
     /// In practice I think it can only produce a conflict if one of the dependencies
     /// (which are used to make the new incompatibilities)
     /// is already in the partial solution with an incompatible version.
-    pub fn add_version(
+    pub(crate) fn add_package_version_incompatibilities(
         &mut self,
         package: DP::P,
         version: DP::V,

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -168,15 +168,7 @@ pub fn resolve<DP: DependencyProvider>(
             };
 
             // Add that package and version if the dependencies are not problematic.
-            let dep_incompats =
-                state.add_incompatibility_from_dependencies(p.clone(), v.clone(), dependencies);
-
-            state.partial_solution.add_version(
-                p.clone(),
-                v.clone(),
-                dep_incompats,
-                &state.incompatibility_store,
-            );
+            state.add_package_version_dependencies(p.clone(), v.clone(), dependencies);
         } else {
             // `dep_incompats` are already in `incompatibilities` so we know there are not satisfied
             // terms and can add the decision directly.


### PR DESCRIPTION
This wrapper avoids accessing the `incompatibility_store` directly in uv code.

Before:

```rust
let dep_incompats = self.pubgrub.add_version(
    package.clone(),
    version.clone(),
    dependencies,
);
self.pubgrub.partial_solution.add_version(
    package.clone(),
    version.clone(),
    dep_incompats,
    &self.pubgrub.incompatibility_store,
);
```

After:

```rust
self.pubgrub.add_incompatibility_from_dependencies(package.clone(), version.clone(), dependencies);
```

`add_incompatibility_from_dependencies` is one of the main methods for the custom interface to pubgrub.