### PR TITLE
Consistency between `Range::iter` and `Range::bounding_range`

### DIFF
--- a/version-ranges/src/lib.rs
+++ b/version-ranges/src/lib.rs
@@ -860,8 +860,10 @@ impl<V: Ord + Clone> Ranges<V> {
     }
 
     /// Iterate over the parts of the range.
-    pub fn iter(&self) -> impl DoubleEndedIterator<Item = (&Bound<V>, &Bound<V>)> {
-        self.segments.iter().map(|(start, end)| (start, end))
+    pub fn iter(&self) -> impl DoubleEndedIterator<Item = (Bound<&V>, Bound<&V>)> {
+        self.segments
+            .iter()
+            .map(|(start, end)| (start.as_ref(), end.as_ref()))
     }
 }
 


### PR DESCRIPTION
Also makes it possible to not store `Bound<V>` inside `Range` in the future.