### PR TITLE
Implement `[Partial]Ord` for `Range`

### DIFF
--- a/src/range.rs
+++ b/src/range.rs
@@ -308,6 +308,100 @@ impl<V: Ord> Range<V> {
     }
 }
 
+/// Implementing `PartialOrd` for start `Bound` of an interval.
+///
+/// ```text
+/// left:   ∞-------]
+/// right:    [-----]
+/// left is smaller, since it starts earlier.
+///
+/// left:   [-----]
+/// right:  ]-----]
+/// left is smaller, since it starts earlier.
+/// ```
+fn cmp_bounds_start<V: PartialOrd>(left: Bound<&V>, right: Bound<&V>) -> Option<Ordering> {
+    match (left, right) {
+        (Unbounded, Unbounded) => Some(Ordering::Equal),
+        (Included(_left), Unbounded) => Some(Ordering::Greater),
+        (Excluded(_left), Unbounded) => Some(Ordering::Greater),
+        (Unbounded, Included(_right)) => Some(Ordering::Less),
+        (Included(left), Included(right)) => left.partial_cmp(right),
+        (Excluded(left), Included(right)) => match left.partial_cmp(right)? {
+            Ordering::Less => Some(Ordering::Less),
+            Ordering::Equal => Some(Ordering::Greater),
+            Ordering::Greater => Some(Ordering::Greater),
+        },
+        (Unbounded, Excluded(_right)) => Some(Ordering::Less),
+        (Included(left), Excluded(right)) => match left.partial_cmp(right)? {
+            Ordering::Less => Some(Ordering::Less),
+            Ordering::Equal => Some(Ordering::Less),
+            Ordering::Greater => Some(Ordering::Greater),
+        },
+        (Excluded(left), Excluded(right)) => left.partial_cmp(right),
+    }
+}
+
+/// Implementing `PartialOrd` for end `Bound` of an interval.
+///
+/// We flip the unbounded ranges from `-∞` to `∞`, while `V`-valued bounds checks remain the same.
+///
+/// ```text
+/// left:   [--------inf
+/// right:  [-----]
+/// left is greater, since it starts earlier.
+///
+/// left:   [-----[
+/// right:  [-----]
+/// left is smaller, since it ends earlier.
+/// ```
+fn cmp_bounds_end<V: PartialOrd>(left: Bound<&V>, right: Bound<&V>) -> Option<Ordering> {
+    match (left, right) {
+        (Unbounded, Unbounded) => Some(Ordering::Equal),
+        (Included(_left), Unbounded) => Some(Ordering::Less),
+        (Excluded(_left), Unbounded) => Some(Ordering::Less),
+        (Unbounded, Included(_right)) => Some(Ordering::Greater),
+        (Included(left), Included(right)) => left.partial_cmp(right),
+        (Excluded(left), Included(right)) => match left.partial_cmp(right)? {
+            Ordering::Less => Some(Ordering::Less),
+            Ordering::Equal => Some(Ordering::Greater),
+            Ordering::Greater => Some(Ordering::Greater),
+        },
+        (Unbounded, Excluded(_right)) => Some(Ordering::Greater),
+        (Included(left), Excluded(right)) => match left.partial_cmp(right)? {
+            Ordering::Less => Some(Ordering::Less),
+            Ordering::Equal => Some(Ordering::Less),
+            Ordering::Greater => Some(Ordering::Greater),
+        },
+        (Excluded(left), Excluded(right)) => left.partial_cmp(right),
+    }
+}
+
+impl<V: PartialOrd> PartialOrd for Range<V> {
+    /// A simple ordering scheme where we zip the segments and compare all bounds in order. If all
+    /// bounds are equal, the longer range is considered greater. (And if all zipped bounds are
+    /// equal and we have the same number of segments, the ranges are equal).
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        for (left, right) in self.segments.iter().zip(other.segments.iter()) {
+            let start_cmp = cmp_bounds_start(left.start_bound(), right.start_bound())?;
+            if start_cmp != Ordering::Equal {
+                return Some(start_cmp);
+            }
+            let end_cmp = cmp_bounds_end(left.end_bound(), right.end_bound())?;
+            if end_cmp != Ordering::Equal {
+                return Some(end_cmp);
+            }
+        }
+        Some(self.segments.len().cmp(&other.segments.len()))
+    }
+}
+
+impl<V: Ord> Ord for Range<V> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.partial_cmp(other)
+            .expect("PartialOrd must be `Some(Ordering)` for types that implement `Ord`")
+    }
+}
+
 /// The ordering of the version wrt to the interval.
 /// ```text
 ///      |-------|

--- a/src/range.rs
+++ b/src/range.rs
@@ -310,6 +310,8 @@ impl<V: Ord> Range<V> {
 
 /// Implementing `PartialOrd` for start `Bound` of an interval.
 ///
+/// Legend: `∞` is unbounded, `[1,2]` is `>1,<2`, `]1,2[` is `>=1,<=2`.
+///
 /// ```text
 /// left:   ∞-------]
 /// right:    [-----]
@@ -345,8 +347,10 @@ fn cmp_bounds_start<V: PartialOrd>(left: Bound<&V>, right: Bound<&V>) -> Option<
 ///
 /// We flip the unbounded ranges from `-∞` to `∞`, while `V`-valued bounds checks remain the same.
 ///
+/// Legend: `∞` is unbounded, `[1,2]` is `>1,<2`, `]1,2[` is `>=1,<=2`.
+///
 /// ```text
-/// left:   [--------inf
+/// left:   [--------∞
 /// right:  [-----]
 /// left is greater, since it starts earlier.
 ///

--- a/src/range.rs
+++ b/src/range.rs
@@ -238,9 +238,9 @@ impl<V: Ord> Range<V> {
     /// The `versions` iterator must be sorted.
     /// Functionally equivalent to `versions.map(|v| self.contains(v))`.
     /// Except it runs in `O(size_of_range + len_of_versions)` not `O(size_of_range * len_of_versions)`
-    pub fn contains_many<'s, I, BV>(&'s self, versions: I) -> impl Iterator<Item=bool> + 's
+    pub fn contains_many<'s, I, BV>(&'s self, versions: I) -> impl Iterator<Item = bool> + 's
     where
-        I: Iterator<Item=BV> + 's,
+        I: Iterator<Item = BV> + 's,
         BV: Borrow<V> + 's,
     {
         #[cfg(debug_assertions)]
@@ -503,8 +503,8 @@ fn left_end_is_smaller<V: PartialOrd>(left: Bound<V>, right: Bound<V>) -> bool {
 /// [None, 1, 4, 7, None, None, None, 8, None, 9] -> [(1, 7), (8, 8), (9, None)]
 /// ```
 fn group_adjacent_locations(
-    mut locations: impl Iterator<Item=Option<usize>>,
-) -> impl Iterator<Item=(Option<usize>, Option<usize>)> {
+    mut locations: impl Iterator<Item = Option<usize>>,
+) -> impl Iterator<Item = (Option<usize>, Option<usize>)> {
     // If the first version matched, then the lower bound of that segment is not needed
     let mut seg = locations.next().flatten().map(|ver| (None, Some(ver)));
     std::iter::from_fn(move || {
@@ -720,7 +720,7 @@ impl<V: Ord + Clone> Range<V> {
     /// If the given versions are not sorted the correctness of this function is not guaranteed.
     pub fn simplify<'s, I, BV>(&self, versions: I) -> Self
     where
-        I: Iterator<Item=BV> + 's,
+        I: Iterator<Item = BV> + 's,
         BV: Borrow<V> + 's,
     {
         // Do not simplify singletons
@@ -770,7 +770,7 @@ impl<V: Ord + Clone> Range<V> {
     /// start of the first and the end of the second.
     fn keep_segments(
         &self,
-        kept_segments: impl Iterator<Item=(Option<usize>, Option<usize>)>,
+        kept_segments: impl Iterator<Item = (Option<usize>, Option<usize>)>,
     ) -> Range<V> {
         let mut segments = SmallVec::Empty;
         for (s, e) in kept_segments {
@@ -783,7 +783,7 @@ impl<V: Ord + Clone> Range<V> {
     }
 
     /// Iterate over the parts of the range.
-    pub fn iter(&self) -> impl Iterator<Item=(&Bound<V>, &Bound<V>)> {
+    pub fn iter(&self) -> impl Iterator<Item = (&Bound<V>, &Bound<V>)> {
         self.segments.iter().map(|(start, end)| (start, end))
     }
 }
@@ -903,7 +903,7 @@ pub mod tests {
 
     /// Generate version sets from a random vector of deltas between bounds.
     /// Each bound is randomly inclusive or exclusive.
-    pub fn strategy() -> impl Strategy<Value=Range<u32>> {
+    pub fn strategy() -> impl Strategy<Value = Range<u32>> {
         (
             any::<bool>(),
             prop::collection::vec(any::<(u32, bool)>(), 1..10),
@@ -965,7 +965,7 @@ pub mod tests {
             })
     }
 
-    fn version_strat() -> impl Strategy<Value=u32> {
+    fn version_strat() -> impl Strategy<Value = u32> {
         any::<u32>()
     }
 


### PR DESCRIPTION
In uv, we want to have a stable ordering of certain types that `Range<Version>`, both for determinism internally and for deterministically ordered output files.

This PR adds `impl<V: PartialOrd> PartialOrd for Range<V>` and `impl<V: Ord> Ord for Range<V>` implementations to `Range`. We use a simple ordering scheme where we zip the segments and compare all bounds in order. If all bounds are equal, the longer range is considered greater. (And if all zipped bounds are equal and we have the same number of segments, the ranges are equal). Not that this is distinct from contains operations, `r1 < r2` (implemented by `Ord`) and `r1 ⊂ r2` (`subset_of`) have no relationship.