### PR TITLE
Add a method to retrieve unchanging terms for a package

### DIFF
--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -521,6 +521,18 @@ impl<DP: DependencyProvider> PartialSolution<DP> {
     pub(crate) fn current_decision_level(&self) -> DecisionLevel {
         self.current_decision_level
     }
+
+    /// Retrieve the constraints on a package that will not change.
+    pub fn unchanging_term_for_package(&self, package: &DP::P) -> Option<&Term<DP::VS>> {
+        let pa = self.package_assignments.get(package)?;
+
+        let idx_newer = pa
+            .dated_derivations
+            .as_slice()
+            .partition_point(|dd| dd.decision_level <= DecisionLevel(1));
+        let idx = idx_newer.checked_sub(1)?;
+        Some(&pa.dated_derivations[idx].accumulated_intersection)
+    }
 }
 
 impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> PackageAssignments<P, VS, M> {


### PR DESCRIPTION
When prefetching, we want to avoid prefetching packages we will certainly reject. `PartialSolution::unchanging_term_for_package` returns the terms from root that a certain independent from the current partial solution. See https://github.com/pubgrub-rs/pubgrub/issues/263#issuecomment-2414871726