### PR TITLE
Allow `Ranges::contains` to accept (e.g.) `&str` for `Ranges<String>`

### DIFF
--- a/src/internal/arena.rs
+++ b/src/internal/arena.rs
@@ -150,14 +150,20 @@ impl<T: Hash + Eq + fmt::Debug> fmt::Debug for HashArena<T> {
 
 impl<T: Hash + Eq> HashArena<T> {
     pub fn new() -> Self {
-        HashArena {
-            data: FnvIndexSet::default(),
-        }
+        Self::default()
     }
 
     pub fn alloc(&mut self, value: T) -> Id<T> {
         let (raw, _) = self.data.insert_full(value);
         Id::from(raw as u32)
+    }
+}
+
+impl<T: Hash + Eq> Default for HashArena<T> {
+    fn default() -> Self {
+        Self {
+            data: FnvIndexSet::default(),
+        }
     }
 }
 

--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -83,7 +83,7 @@ impl<DP: DependencyProvider> State<DP> {
         let dep_incompats =
             self.add_incompatibility_from_dependencies(package, version.clone(), dependencies);
         self.partial_solution.add_package_version_incompatibilities(
-            package.clone(),
+            package,
             version.clone(),
             dep_incompats,
             &self.incompatibility_store,

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -171,7 +171,7 @@ pub fn resolve<DP: DependencyProvider>(
             };
 
             // Add that package and version if the dependencies are not problematic.
-            state.add_package_version_dependencies(p.clone(), v.clone(), dependencies);
+            state.add_package_version_dependencies(p, v.clone(), dependencies);
         } else {
             // `dep_incompats` are already in `incompatibilities` so we know there are not satisfied
             // terms and can add the decision directly.


### PR DESCRIPTION
## Summary

This PR borrows a trick from [HashMap](https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.contains_key) to enable users to pass (e.g.) `&str` to `Ranges::contains`, given `Ranges<String>`.