### PR TITLE
Return incompatibility from conflict & Allow backtracking to before a specific package 

### DIFF
--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -264,7 +264,8 @@ impl<DP: DependencyProvider> State<DP> {
         }
     }
 
-    /// Backtracking.
+    /// After a conflict occurred, backtrack the partial solution to a given decision level, and add
+    /// the incompatibility if it was new.
     fn backtrack(
         &mut self,
         incompat: IncompDpId<DP>,
@@ -278,6 +279,21 @@ impl<DP: DependencyProvider> State<DP> {
         if incompat_changed {
             self.merge_incompatibility(incompat);
         }
+    }
+
+    /// Manually backtrack before the given package was selected.
+    ///
+    /// This can be used to switch the order of packages if the previous prioritization was bad.
+    ///
+    /// Returns the number of the decisions that were backtracked, or `None` if the package was not
+    /// decided on yet.
+    pub fn backtrack_package(&mut self, package: Id<DP::P>) -> Option<u32> {
+        let base_decision_level = self.partial_solution.current_decision_level();
+        let new_decision_level = self.partial_solution.backtrack_package(package).ok()?;
+        // Remove contradicted incompatibilities that depend on decisions we just backtracked away.
+        self.contradicted_incompatibilities
+            .retain(|_, dl| *dl <= new_decision_level);
+        Some(base_decision_level.0 - new_decision_level.0)
     }
 
     /// Add this incompatibility into the set of all incompatibilities.

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -12,6 +12,9 @@ use crate::{
     VersionSet,
 };
 
+// An entry in an incompatibility when iterating over one.
+pub(crate) type IncompatIterItem<'term, P, VS> = (Id<P>, &'term Term<VS>);
+
 /// An incompatibility is a set of terms for different packages
 /// that should never be satisfied all together.
 /// An incompatibility usually originates from a package dependency.
@@ -248,7 +251,7 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
     }
 
     /// Iterate over packages.
-    pub(crate) fn iter(&self) -> impl Iterator<Item = (Id<P>, &Term<VS>)> {
+    pub(crate) fn iter(&self) -> impl Iterator<Item = IncompatIterItem<'_, P, VS>> {
         self.package_terms
             .iter()
             .map(|(package, term)| (*package, term))

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -10,7 +10,7 @@ mod small_map;
 mod small_vec;
 
 pub(crate) use arena::{Arena, HashArena};
-pub(crate) use incompatibility::{IncompDpId, IncompId, Relation};
+pub(crate) use incompatibility::{IncompDpId, IncompId, IncompatIterItem, Relation};
 pub(crate) use partial_solution::{DecisionLevel, PartialSolution, SatisfierSearch};
 pub(crate) use small_map::SmallMap;
 pub(crate) use small_vec::SmallVec;

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -212,6 +212,13 @@ impl<DP: DependencyProvider> PartialSolution<DP> {
         self.next_global_index += 1;
     }
 
+    /// The list of package that have not been selected after the last prioritization.
+    ///
+    /// This list gets updated by [`Self::pick_highest_priority_pkg`] and cleared by backtracking.
+    pub fn undecided_packages(&self) -> impl Iterator<Item = (&Id<DP::P>, &DP::Priority)> {
+        self.prioritized_potential_packages.iter()
+    }
+
     /// Add a derivation.
     pub(crate) fn add_derivation(
         &mut self,

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -6,6 +6,7 @@
 use std::fmt::{Debug, Display};
 use std::hash::BuildHasherDefault;
 
+use log::debug;
 use priority_queue::PriorityQueue;
 use rustc_hash::FxHasher;
 
@@ -383,6 +384,28 @@ impl<DP: DependencyProvider> PartialSolution<DP> {
         self.prioritized_potential_packages.clear();
         self.changed_this_decision_level = self.current_decision_level.0.saturating_sub(1) as usize;
         self.has_ever_backtracked = true;
+    }
+
+    /// Backtrack the partial solution before a particular package was selected.
+    ///
+    /// This can be used to switch the order of packages if the previous prioritization was bad.
+    ///
+    /// Returns the new decision level on success and an error if the package was not decided on
+    /// yet.
+    pub(crate) fn backtrack_package(&mut self, package: Id<DP::P>) -> Result<DecisionLevel, ()> {
+        let Some(decision_level) = self.package_assignments.get_index_of(&package) else {
+            return Err(());
+        };
+        let decision_level = DecisionLevel(decision_level as u32);
+        if decision_level > self.current_decision_level {
+            return Err(());
+        }
+        debug!(
+            "Package backtracking ot decision level {}",
+            decision_level.0
+        );
+        self.backtrack(decision_level);
+        Ok(decision_level)
     }
 
     /// Add a package version as decision if none of its dependencies conflicts with the partial


### PR DESCRIPTION
Background reading: https://github.com/astral-sh/uv/issues/8157

I'll link the PR on the uv side with all the details once it's up, it contains a walkthrough.

This adds two features to pubgrub:

Return incompatibility from conflict: Whenever we either discard a version due to its dependencies or perform conflict resolution, we return the last conflict that led to discarding them. In uv, we use this to re-prioritize and backtrack when a package decision accumulated to many conflicts. Using the incompatibilities directly from pubgrub makes this efficient.

Allow backtracking to before a specific package: Once we identified a pair of conflicting packages, we want to switch their priorities. This requires backtracking to before the decision for the earlier of the two packages was made. On the uv side, we change the priorities to make sure we take a different path on the next attempt. We allow attempting to backtrack on packages that were not decided yet to avoid the caller from making the duplicative check: At the time when the see incompatibilities caused by them, they are not necessarily decided.

Best reviewed commit-by-commit.