### PR TITLE
Rename to `astral-pubgrub` to publish to crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "astral-pubgrub"
+version = "0.3.0"
+dependencies = [
+ "codspeed-criterion-compat",
+ "env_logger",
+ "indexmap",
+ "log",
+ "priority-queue",
+ "proptest",
+ "ron",
+ "rustc-hash 2.1.1",
+ "serde",
+ "thiserror 2.0.17",
+ "varisat",
+ "version-ranges",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -676,24 +694,6 @@ dependencies = [
  "rusty-fork",
  "tempfile",
  "unarray",
-]
-
-[[package]]
-name = "pubgrub"
-version = "0.3.0"
-dependencies = [
- "codspeed-criterion-compat",
- "env_logger",
- "indexmap",
- "log",
- "priority-queue",
- "proptest",
- "ron",
- "rustc-hash 2.1.1",
- "serde",
- "thiserror 2.0.17",
- "varisat",
- "version-ranges",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@
 members = ["version-ranges"]
 
 [package]
-name = "pubgrub"
+name = "astral-pubgrub"
 version = "0.3.0"
 authors = [
     "Matthieu Pizenberg <matthieu.pizenberg@gmail.com>",

--- a/benches/backtracking.rs
+++ b/benches/backtracking.rs
@@ -4,8 +4,8 @@
 //!
 //! Dependencies are constructed in a way that all versions need to be tested before finding a solution.
 
+use astral_pubgrub::OfflineDependencyProvider;
 use criterion::*;
-use pubgrub::OfflineDependencyProvider;
 use version_ranges::Ranges;
 
 /// This benchmark is a simplified reproduction of one of the patterns found in the `solana-*` crates from Cargo:

--- a/benches/large_case.rs
+++ b/benches/large_case.rs
@@ -5,7 +5,9 @@ use std::time::Duration;
 use criterion::*;
 use serde::de::Deserialize;
 
-use pubgrub::{OfflineDependencyProvider, Package, Range, SemanticVersion, VersionSet, resolve};
+use astral_pubgrub::{
+    OfflineDependencyProvider, Package, Range, SemanticVersion, VersionSet, resolve,
+};
 
 fn bench<'a, P: Package + Deserialize<'a>, VS: VersionSet + Deserialize<'a>>(
     b: &mut Bencher,

--- a/benches/sudoku.rs
+++ b/benches/sudoku.rs
@@ -3,7 +3,7 @@
 //! Uses `Arc<usize>` for being closer to real versions.
 // SPDX-License-Identifier: MPL-2.0
 
-use pubgrub::{OfflineDependencyProvider, Range, resolve};
+use astral_pubgrub::{OfflineDependencyProvider, Range, resolve};
 use std::fmt;
 use std::sync::Arc;
 use version_ranges::Ranges;

--- a/examples/branching_error_reporting.rs
+++ b/examples/branching_error_reporting.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use pubgrub::{
+use astral_pubgrub::{
     DefaultStringReporter, OfflineDependencyProvider, PubGrubError, Ranges, Reporter,
     SemanticVersion, resolve,
 };

--- a/examples/caching_dependency_provider.rs
+++ b/examples/caching_dependency_provider.rs
@@ -2,7 +2,7 @@
 
 use std::cell::RefCell;
 
-use pubgrub::{
+use astral_pubgrub::{
     Dependencies, DependencyProvider, OfflineDependencyProvider, PackageResolutionStatistics,
     Ranges, resolve,
 };

--- a/examples/doc_interface.rs
+++ b/examples/doc_interface.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use pubgrub::{OfflineDependencyProvider, Ranges, resolve};
+use astral_pubgrub::{OfflineDependencyProvider, Ranges, resolve};
 
 type NumVS = Ranges<u32>;
 

--- a/examples/doc_interface_error.rs
+++ b/examples/doc_interface_error.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use pubgrub::{
+use astral_pubgrub::{
     DefaultStringReporter, OfflineDependencyProvider, PubGrubError, Ranges, Reporter,
     SemanticVersion, resolve,
 };

--- a/examples/doc_interface_semantic.rs
+++ b/examples/doc_interface_semantic.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use pubgrub::{
+use astral_pubgrub::{
     DefaultStringReporter, OfflineDependencyProvider, PubGrubError, Ranges, Reporter,
     SemanticVersion, resolve,
 };

--- a/examples/linear_error_reporting.rs
+++ b/examples/linear_error_reporting.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use pubgrub::{
+use astral_pubgrub::{
     DefaultStringReporter, OfflineDependencyProvider, PubGrubError, Ranges, Reporter,
     SemanticVersion, resolve,
 };

--- a/examples/unsat_root_message_no_version.rs
+++ b/examples/unsat_root_message_no_version.rs
@@ -2,7 +2,7 @@
 
 use std::fmt::{self, Display};
 
-use pubgrub::{
+use astral_pubgrub::{
     DefaultStringReporter, Derived, External, Map, OfflineDependencyProvider, PubGrubError, Ranges,
     ReportFormatter, Reporter, SemanticVersion, Term, resolve,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@
 //!
 //! We can model that scenario with this library as follows
 //! ```
-//! # use pubgrub::{OfflineDependencyProvider, resolve, Ranges};
+//! # use astral_pubgrub::{OfflineDependencyProvider, resolve, Ranges};
 //!
 //! type NumVS = Ranges<u32>;
 //!
@@ -72,7 +72,7 @@
 //! and [SemanticVersion] for versions.
 //! This may be done quite easily by implementing the three following functions.
 //! ```
-//! # use pubgrub::{DependencyProvider, Dependencies, SemanticVersion, Ranges,
+//! # use astral_pubgrub::{DependencyProvider, Dependencies, SemanticVersion, Ranges,
 //! #               DependencyConstraints, Map, PackageResolutionStatistics};
 //! # use std::error::Error;
 //! # use std::borrow::Borrow;
@@ -159,7 +159,7 @@
 //! This crate defines a [Reporter] trait, with an associated
 //! [Output](Reporter::Output) type and a single method.
 //! ```
-//! # use pubgrub::{Package, VersionSet, DerivationTree};
+//! # use astral_pubgrub::{Package, VersionSet, DerivationTree};
 //! # use std::fmt::{Debug, Display};
 //! #
 //! pub trait Reporter<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> {
@@ -174,7 +174,7 @@
 //! [DefaultStringReporter] that outputs the report as a [String].
 //! You may use it as follows:
 //! ```
-//! # use pubgrub::{resolve, OfflineDependencyProvider, DefaultStringReporter, Reporter, PubGrubError, Ranges};
+//! # use astral_pubgrub::{resolve, OfflineDependencyProvider, DefaultStringReporter, Reporter, PubGrubError, Ranges};
 //! #
 //! # type NumVS = Ranges<u32>;
 //! #

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -84,7 +84,7 @@ impl PackageResolutionStatistics {
 ///
 /// ```
 /// # use std::convert::Infallible;
-/// # use pubgrub::{resolve, OfflineDependencyProvider, PubGrubError, Ranges};
+/// # use astral_pubgrub::{resolve, OfflineDependencyProvider, PubGrubError, Ranges};
 /// #
 /// # type NumVS = Ranges<u32>;
 /// #

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use pubgrub::{
+use astral_pubgrub::{
     DefaultStringReporter, Map, OfflineDependencyProvider, PubGrubError, Ranges, Reporter as _,
     SemanticVersion, Set, resolve,
 };

--- a/tests/proptest.rs
+++ b/tests/proptest.rs
@@ -11,7 +11,7 @@ use proptest::prelude::*;
 use proptest::sample::Index;
 use proptest::string::string_regex;
 
-use pubgrub::{
+use astral_pubgrub::{
     DefaultStringReporter, Dependencies, DependencyProvider, DerivationTree, External,
     OfflineDependencyProvider, Package, PackageResolutionStatistics, PubGrubError, Ranges,
     Reporter, SelectedDependencies, VersionSet, resolve,

--- a/tests/sat_dependency_provider.rs
+++ b/tests/sat_dependency_provider.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use pubgrub::{
+use astral_pubgrub::{
     Dependencies, DependencyProvider, Map, OfflineDependencyProvider, Package, PubGrubError,
     SelectedDependencies, VersionSet,
 };

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
-use pubgrub::{OfflineDependencyProvider, PubGrubError, Ranges, resolve};
+use astral_pubgrub::{OfflineDependencyProvider, PubGrubError, Ranges, resolve};
 
 type NumVS = Ranges<u32>;
 


### PR DESCRIPTION
Bigger diff than I'd like due to https://github.com/rust-lang/cargo/issues/16252.

We need to do a first publish to start using trusted publishing.