### PR TITLE
Use a token for astral-version-ranges publish

### DIFF
--- a/.github/workflows/publish-version-ranges.yml
+++ b/.github/workflows/publish-version-ranges.yml
@@ -7,13 +7,8 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write # Required for OIDC token exchange
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
-      - uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1
-        id: auth
-        working-directory: version-ranges
       - run: cargo publish -p astral-version-ranges
         env:
-          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.ASTRAL_VERSION_RANGES_CRATES_IO_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,7 +102,7 @@ dependencies = [
 
 [[package]]
 name = "astral-version-ranges"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "proptest",
  "ron",

--- a/version-ranges/Cargo.toml
+++ b/version-ranges/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astral-version-ranges"
-version = "0.1.2"
+version = "0.1.3"
 description = "Performance-optimized type for generic version ranges and operations on them."
 edition = "2021"
 repository = "https://github.com/pubgrub-rs/pubgrub"


### PR DESCRIPTION
See https://github.com/rust-lang/crates-io-auth-action/issues/111