### PR TITLE
Fix `Minimal versions` CI by lifting tempfile and is-terminal floors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,11 @@ criterion = { version = "4.0.1", package = "codspeed-criterion-compat" }
 env_logger = "0.11.6"
 proptest = "1.6.0"
 ron = "0.12.0"
+# `-Zminimal-versions` floors: keep the transitive `rustix` off 0.37 (broken
+# on current nightly, see bytecodealliance/rustix#1620). Two roots pull it:
+# `proptest -> tempfile` and `codspeed-criterion-compat -> is-terminal`.
+is-terminal = "0.4.8"
+tempfile = "3.7"
 varisat = "0.2.2"
 version-ranges = { version = "0.1.0", path = "version-ranges", package = "astral-version-ranges", features = ["proptest"] }
 


### PR DESCRIPTION
The `Minimal versions` job has been red on `main` since 2026-05-07. Root cause is two transitive paths pulling `rustix = "0.37"`:

- `proptest 1.6.0 -> tempfile 3.0 -> rustix 0.37`
- `codspeed-criterion-compat 4.0.1 -> is-terminal 0.4.6 -> rustix 0.37`

rustix `0.37.x` uses `rustc_layout_scalar_valid_range_start`, the perma-unstable attribute removed from the compiler in rust-lang/rust#155433 (merged 2026-05-03). Tracking issue: bytecodealliance/rustix#1620. The 0.37 line is in deep maintenance (0.37.28 released 2025-01-07) and no backport is in flight.

This adds two direct dev-dep floors, the minimum each path needs to land on rustix `0.38+`:

- `tempfile = "3.7"` (3.7.0 is the first to require `rustix = "0.38"`)
- `is-terminal = "0.4.8"` (0.4.8 is the first to require `rustix = "0.38"`)

Normal builds are unaffected: the resolver already picks `tempfile 3.15.0` and `is-terminal 0.4.15`.

Verified locally with `cargo +nightly update -Zminimal-versions && cargo +nightly build --workspace`: the lockfile resolves to a single `rustix v0.38.0`, no `rustix v0.37.x` anywhere in the tree.

## AI assistance

Diagnosis, dep-chain trace, and Cargo.toml diff drafted with AI assistance and verified locally against the failing CI job. Reviewed and own the change.