### PR TITLE
Store contradicted incompatibilities in a dense Vec instead of a hash map

### DIFF
--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -64,17 +64,54 @@ impl<DP: DependencyProvider> ContradictedIncompatibilities<DP> {
     /// Forget every entry recorded at a decision level strictly greater than `decision_level`.
     #[inline]
     fn retain_le(&mut self, decision_level: DecisionLevel) {
-        // `None` is the niche (the all-zero word), so it orders below every
-        // `Some(level)`. That makes `slot > Some(decision_level)` true exactly
-        // for the contradicted entries above the threshold and false for `None`,
-        // so this lowers to a single flat comparison per slot with no separate
-        // is-contradicted branch.
+        // `Option` orders `None` below every `Some(level)`. Therefore,
+        // `slot > Some(decision_level)` is true exactly for contradicted entries
+        // above the threshold and false for `None`.
         let limit = Some(decision_level);
         for slot in &mut self.levels {
             if *slot > limit {
                 *slot = None;
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{OfflineDependencyProvider, Ranges};
+
+    type TestProvider = OfflineDependencyProvider<&'static str, Ranges<u32>>;
+
+    #[test]
+    fn contradicted_incompatibilities_track_and_backtrack_levels() {
+        let mut packages = HashArena::new();
+        let root = packages.alloc("root");
+        let mut incompatibilities: Arena<Incompatibility<&str, Ranges<u32>, String>> = Arena::new();
+        let ids: [IncompDpId<TestProvider>; 3] =
+            std::array::from_fn(|_| incompatibilities.alloc(Incompatibility::not_root(root, 0)));
+
+        let mut contradicted = ContradictedIncompatibilities::<TestProvider>::default();
+        contradicted.insert(ids[2], DecisionLevel::new(3));
+
+        assert_eq!(contradicted.levels.len(), 3);
+        assert!(!contradicted.is_contradicted(ids[0]));
+        assert!(!contradicted.is_contradicted(ids[1]));
+        assert!(contradicted.is_contradicted(ids[2]));
+
+        contradicted.insert(ids[0], DecisionLevel::new(1));
+        contradicted.insert(ids[1], DecisionLevel::new(2));
+        contradicted.retain_le(DecisionLevel::new(2));
+
+        assert!(contradicted.is_contradicted(ids[0]));
+        assert!(contradicted.is_contradicted(ids[1]));
+        assert!(!contradicted.is_contradicted(ids[2]));
+
+        contradicted.retain_le(DecisionLevel::ZERO);
+
+        assert!(!contradicted.is_contradicted(ids[0]));
+        assert!(!contradicted.is_contradicted(ids[1]));
+        assert!(!contradicted.is_contradicted(ids[2]));
     }
 }
 

--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -4,6 +4,7 @@
 //! to write a functional PubGrub algorithm.
 
 use std::collections::HashSet as Set;
+use std::marker::PhantomData;
 use std::sync::Arc;
 
 use crate::internal::{
@@ -25,14 +26,14 @@ struct ContradictedIncompatibilities<DP: DependencyProvider> {
     /// `levels[id]` is `Some(dl)` if the incompatibility was found contradicted at decision
     /// level `dl`, and `None` if it is not currently contradicted.
     levels: Vec<Option<DecisionLevel>>,
-    _provider: std::marker::PhantomData<fn() -> DP>,
+    _provider: PhantomData<fn() -> DP>,
 }
 
 impl<DP: DependencyProvider> Clone for ContradictedIncompatibilities<DP> {
     fn clone(&self) -> Self {
         Self {
             levels: self.levels.clone(),
-            _provider: std::marker::PhantomData,
+            _provider: PhantomData,
         }
     }
 }
@@ -41,17 +42,21 @@ impl<DP: DependencyProvider> Default for ContradictedIncompatibilities<DP> {
     fn default() -> Self {
         Self {
             levels: Vec::new(),
-            _provider: std::marker::PhantomData,
+            _provider: PhantomData,
         }
     }
 }
 
 impl<DP: DependencyProvider> ContradictedIncompatibilities<DP> {
+    /// Returns whether `id` is currently contradicted.
+    ///
+    /// IDs beyond the allocated slots have not been seen yet and therefore return `false`.
     #[inline]
     fn is_contradicted(&self, id: IncompDpId<DP>) -> bool {
         matches!(self.levels.get(id.into_raw()), Some(Some(_)))
     }
 
+    /// Records that `id` is contradicted at `decision_level`, growing the dense table as needed.
     #[inline]
     fn insert(&mut self, id: IncompDpId<DP>, decision_level: DecisionLevel) {
         let idx = id.into_raw();
@@ -92,26 +97,25 @@ mod tests {
             std::array::from_fn(|_| incompatibilities.alloc(Incompatibility::not_root(root, 0)));
 
         let mut contradicted = ContradictedIncompatibilities::<TestProvider>::default();
+        let statuses = |contradicted: &ContradictedIncompatibilities<TestProvider>| {
+            ids.map(|id| contradicted.is_contradicted(id))
+        };
+        assert_eq!(statuses(&contradicted), [false; 3]);
+
         contradicted.insert(ids[2], DecisionLevel::new(3));
 
         assert_eq!(contradicted.levels.len(), 3);
-        assert!(!contradicted.is_contradicted(ids[0]));
-        assert!(!contradicted.is_contradicted(ids[1]));
-        assert!(contradicted.is_contradicted(ids[2]));
+        assert_eq!(statuses(&contradicted), [false, false, true]);
 
         contradicted.insert(ids[0], DecisionLevel::new(1));
         contradicted.insert(ids[1], DecisionLevel::new(2));
         contradicted.retain_le(DecisionLevel::new(2));
 
-        assert!(contradicted.is_contradicted(ids[0]));
-        assert!(contradicted.is_contradicted(ids[1]));
-        assert!(!contradicted.is_contradicted(ids[2]));
+        assert_eq!(statuses(&contradicted), [true, true, false]);
 
         contradicted.retain_le(DecisionLevel::ZERO);
 
-        assert!(!contradicted.is_contradicted(ids[0]));
-        assert!(!contradicted.is_contradicted(ids[1]));
-        assert!(!contradicted.is_contradicted(ids[2]));
+        assert_eq!(statuses(&contradicted), [false; 3]);
     }
 }
 

--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -21,21 +21,39 @@ use crate::{DependencyProvider, DerivationTree, Map, NoSolutionError, VersionSet
 /// load instead of a hash lookup, which matters because that check runs many times per
 /// incompatibility per propagation round. `DecisionLevel` carries a niche, so each entry is
 /// `Option<DecisionLevel>` in 4 bytes, no wider than a bare id-to-level array would be.
-#[derive(Clone, Debug, Default)]
-struct ContradictedIncompatibilities {
+struct ContradictedIncompatibilities<DP: DependencyProvider> {
     /// `levels[id]` is `Some(dl)` if the incompatibility was found contradicted at decision
     /// level `dl`, and `None` if it is not currently contradicted.
     levels: Vec<Option<DecisionLevel>>,
+    _provider: std::marker::PhantomData<fn() -> DP>,
 }
 
-impl ContradictedIncompatibilities {
+impl<DP: DependencyProvider> Clone for ContradictedIncompatibilities<DP> {
+    fn clone(&self) -> Self {
+        Self {
+            levels: self.levels.clone(),
+            _provider: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<DP: DependencyProvider> Default for ContradictedIncompatibilities<DP> {
+    fn default() -> Self {
+        Self {
+            levels: Vec::new(),
+            _provider: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<DP: DependencyProvider> ContradictedIncompatibilities<DP> {
     #[inline]
-    fn is_contradicted<T>(&self, id: Id<T>) -> bool {
+    fn is_contradicted(&self, id: IncompDpId<DP>) -> bool {
         matches!(self.levels.get(id.into_raw()), Some(Some(_)))
     }
 
     #[inline]
-    fn insert<T>(&mut self, id: Id<T>, decision_level: DecisionLevel) {
+    fn insert(&mut self, id: IncompDpId<DP>, decision_level: DecisionLevel) {
         let idx = id.into_raw();
         if idx >= self.levels.len() {
             self.levels.resize(idx + 1, None);
@@ -75,7 +93,7 @@ pub struct State<DP: DependencyProvider> {
     ///
     /// For each one keep track of the decision level when it was found to be contradicted.
     /// These will stay contradicted until we have backtracked beyond its associated decision level.
-    contradicted_incompatibilities: ContradictedIncompatibilities,
+    contradicted_incompatibilities: ContradictedIncompatibilities<DP>,
 
     /// All incompatibilities expressing dependencies,
     /// with common dependents merged.

--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -12,6 +12,54 @@ use crate::internal::{
 };
 use crate::{DependencyProvider, DerivationTree, Map, NoSolutionError, VersionSet};
 
+/// Tracks, for each incompatibility, the decision level at which it was last found to be
+/// contradicted (if any).
+///
+/// Incompatibility ids are dense `u32` arena indices, so this is stored as a flat `Vec` indexed
+/// by the raw id with a sentinel for "not currently contradicted", rather than a hash map. This
+/// makes the `is_contradicted` check on the hot `unit_propagation` path a bounds-checked array
+/// load instead of a hash lookup, which matters because that check runs many times per
+/// incompatibility per propagation round.
+#[derive(Clone, Debug, Default)]
+struct ContradictedIncompatibilities {
+    /// `levels[id] == NOT_CONTRADICTED` means the incompatibility is not currently contradicted;
+    /// otherwise it stores the `DecisionLevel` (as `u32`) at which it was found contradicted.
+    levels: Vec<u32>,
+}
+
+impl ContradictedIncompatibilities {
+    /// Sentinel value meaning "not currently contradicted". `DecisionLevel` is the number of
+    /// decisions made, which cannot reach `u32::MAX` in practice.
+    const NOT_CONTRADICTED: u32 = u32::MAX;
+
+    #[inline]
+    fn is_contradicted<T>(&self, id: Id<T>) -> bool {
+        self.levels
+            .get(id.into_raw())
+            .is_some_and(|&dl| dl != Self::NOT_CONTRADICTED)
+    }
+
+    #[inline]
+    fn insert<T>(&mut self, id: Id<T>, decision_level: DecisionLevel) {
+        let idx = id.into_raw();
+        if idx >= self.levels.len() {
+            self.levels.resize(idx + 1, Self::NOT_CONTRADICTED);
+        }
+        self.levels[idx] = decision_level.0;
+    }
+
+    /// Forget every entry recorded at a decision level strictly greater than `decision_level`.
+    #[inline]
+    fn retain_le(&mut self, decision_level: DecisionLevel) {
+        let threshold = decision_level.0;
+        for dl in &mut self.levels {
+            if *dl != Self::NOT_CONTRADICTED && *dl > threshold {
+                *dl = Self::NOT_CONTRADICTED;
+            }
+        }
+    }
+}
+
 /// Current state of the PubGrub algorithm.
 #[derive(Clone)]
 pub struct State<DP: DependencyProvider> {
@@ -27,7 +75,7 @@ pub struct State<DP: DependencyProvider> {
     ///
     /// For each one keep track of the decision level when it was found to be contradicted.
     /// These will stay contradicted until we have backtracked beyond its associated decision level.
-    contradicted_incompatibilities: Map<IncompDpId<DP>, DecisionLevel>,
+    contradicted_incompatibilities: ContradictedIncompatibilities,
 
     /// All incompatibilities expressing dependencies,
     /// with common dependents merged.
@@ -65,7 +113,7 @@ impl<DP: DependencyProvider> State<DP> {
             root_package,
             root_version,
             incompatibilities,
-            contradicted_incompatibilities: Map::default(),
+            contradicted_incompatibilities: ContradictedIncompatibilities::default(),
             partial_solution: PartialSolution::empty(),
             incompatibility_store,
             package_store,
@@ -179,7 +227,7 @@ impl<DP: DependencyProvider> State<DP> {
             for &incompat_id in self.incompatibilities[&current_package].iter().rev() {
                 if self
                     .contradicted_incompatibilities
-                    .contains_key(&incompat_id)
+                    .is_contradicted(incompat_id)
                 {
                     continue;
                 }
@@ -334,7 +382,7 @@ impl<DP: DependencyProvider> State<DP> {
         self.partial_solution.backtrack(decision_level);
         // Remove contradicted incompatibilities that depend on decisions we just backtracked away.
         self.contradicted_incompatibilities
-            .retain(|_, dl| *dl <= decision_level);
+            .retain_le(decision_level);
         if incompat_changed {
             self.merge_incompatibility(incompat);
         }
@@ -351,7 +399,7 @@ impl<DP: DependencyProvider> State<DP> {
         let new_decision_level = self.partial_solution.backtrack_package(package).ok()?;
         // Remove contradicted incompatibilities that depend on decisions we just backtracked away.
         self.contradicted_incompatibilities
-            .retain(|_, dl| *dl <= new_decision_level);
+            .retain_le(new_decision_level);
         Some(base_decision_level.0 - new_decision_level.0)
     }
 

--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -16,45 +16,45 @@ use crate::{DependencyProvider, DerivationTree, Map, NoSolutionError, VersionSet
 /// contradicted (if any).
 ///
 /// Incompatibility ids are dense `u32` arena indices, so this is stored as a flat `Vec` indexed
-/// by the raw id with a sentinel for "not currently contradicted", rather than a hash map. This
+/// by the raw id, with `None` for "not currently contradicted", rather than a hash map. This
 /// makes the `is_contradicted` check on the hot `unit_propagation` path a bounds-checked array
 /// load instead of a hash lookup, which matters because that check runs many times per
-/// incompatibility per propagation round.
+/// incompatibility per propagation round. `DecisionLevel` carries a niche, so each entry is
+/// `Option<DecisionLevel>` in 4 bytes, no wider than a bare id-to-level array would be.
 #[derive(Clone, Debug, Default)]
 struct ContradictedIncompatibilities {
-    /// `levels[id] == NOT_CONTRADICTED` means the incompatibility is not currently contradicted;
-    /// otherwise it stores the `DecisionLevel` (as `u32`) at which it was found contradicted.
-    levels: Vec<u32>,
+    /// `levels[id]` is `Some(dl)` if the incompatibility was found contradicted at decision
+    /// level `dl`, and `None` if it is not currently contradicted.
+    levels: Vec<Option<DecisionLevel>>,
 }
 
 impl ContradictedIncompatibilities {
-    /// Sentinel value meaning "not currently contradicted". `DecisionLevel` is the number of
-    /// decisions made, which cannot reach `u32::MAX` in practice.
-    const NOT_CONTRADICTED: u32 = u32::MAX;
-
     #[inline]
     fn is_contradicted<T>(&self, id: Id<T>) -> bool {
-        self.levels
-            .get(id.into_raw())
-            .is_some_and(|&dl| dl != Self::NOT_CONTRADICTED)
+        matches!(self.levels.get(id.into_raw()), Some(Some(_)))
     }
 
     #[inline]
     fn insert<T>(&mut self, id: Id<T>, decision_level: DecisionLevel) {
         let idx = id.into_raw();
         if idx >= self.levels.len() {
-            self.levels.resize(idx + 1, Self::NOT_CONTRADICTED);
+            self.levels.resize(idx + 1, None);
         }
-        self.levels[idx] = decision_level.0;
+        self.levels[idx] = Some(decision_level);
     }
 
     /// Forget every entry recorded at a decision level strictly greater than `decision_level`.
     #[inline]
     fn retain_le(&mut self, decision_level: DecisionLevel) {
-        let threshold = decision_level.0;
-        for dl in &mut self.levels {
-            if *dl != Self::NOT_CONTRADICTED && *dl > threshold {
-                *dl = Self::NOT_CONTRADICTED;
+        // `None` is the niche (the all-zero word), so it orders below every
+        // `Some(level)`. That makes `slot > Some(decision_level)` true exactly
+        // for the contradicted entries above the threshold and false for `None`,
+        // so this lowers to a single flat comparison per slot with no separate
+        // is-contradicted branch.
+        let limit = Some(decision_level);
+        for slot in &mut self.levels {
+            if *slot > limit {
+                *slot = None;
             }
         }
     }
@@ -400,7 +400,7 @@ impl<DP: DependencyProvider> State<DP> {
         // Remove contradicted incompatibilities that depend on decisions we just backtracked away.
         self.contradicted_incompatibilities
             .retain_le(new_decision_level);
-        Some(base_decision_level.0 - new_decision_level.0)
+        Some(base_decision_level.get() - new_decision_level.get())
     }
 
     /// Add this incompatibility into the set of all incompatibilities.

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -46,6 +46,7 @@ impl DecisionLevel {
         self.0.get() - 1
     }
 
+    /// Advances to the next decision level, panicking if the representation is exhausted.
     pub(crate) fn increment(self) -> Self {
         Self(self.0.checked_add(1).expect("decision level overflow"))
     }

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -6,6 +6,7 @@
 use std::cmp::Reverse;
 use std::fmt::{Debug, Display};
 use std::hash::BuildHasherDefault;
+use std::num::NonZeroU32;
 
 use log::debug;
 use priority_queue::PriorityQueue;
@@ -19,14 +20,49 @@ use crate::{DependencyProvider, Package, Term, VersionSet};
 type FnvIndexMap<K, V> = indexmap::IndexMap<K, V, BuildHasherDefault<FxHasher>>;
 type FnvIndexSet<T> = indexmap::IndexSet<T, BuildHasherDefault<FxHasher>>;
 
-#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
-pub(crate) struct DecisionLevel(pub(crate) u32);
+/// The number of decisions that have been made at some point in solving.
+///
+/// The logical level is zero-based, but it is stored as `level + 1` in a
+/// `NonZeroU32` so that `Option<DecisionLevel>` fits in the same 4 bytes as a
+/// bare `u32`, with `None` occupying the all-zero niche. That lets `core`
+/// track contradicted incompatibilities as a compact `Vec<Option<DecisionLevel>>`
+/// instead of a `Vec<u32>` with a hand-rolled sentinel.
+#[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
+pub(crate) struct DecisionLevel(NonZeroU32);
 
 impl DecisionLevel {
+    /// Decision level zero: no decisions have been made yet.
+    pub(crate) const ZERO: DecisionLevel = DecisionLevel(NonZeroU32::MIN);
+
+    /// Build a `DecisionLevel` from its zero-based logical value.
+    pub(crate) fn new(level: u32) -> Self {
+        // `level + 1` is always >= 1; the only overflow would be `u32::MAX`
+        // decisions, which the solver cannot reach.
+        Self(NonZeroU32::new(level + 1).expect("decision level overflow"))
+    }
+
+    /// The zero-based logical decision level.
+    pub(crate) fn get(self) -> u32 {
+        self.0.get() - 1
+    }
+
     pub(crate) fn increment(self) -> Self {
-        Self(self.0 + 1)
+        Self(self.0.checked_add(1).expect("decision level overflow"))
     }
 }
+
+impl Debug for DecisionLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "DecisionLevel({})", self.get())
+    }
+}
+
+// The niche is the whole point: `Option<DecisionLevel>` must stay as small as a
+// bare `u32` so `core`'s contradicted-incompatibility map pays nothing for the
+// readability of `Vec<Option<DecisionLevel>>`.
+const _: () = assert!(
+    std::mem::size_of::<Option<DecisionLevel>>() == std::mem::size_of::<u32>()
+);
 
 /// The partial solution contains all package assignments,
 /// organized by package and historically ordered.
@@ -169,7 +205,7 @@ impl<DP: DependencyProvider> PartialSolution<DP> {
     pub(crate) fn empty() -> Self {
         Self {
             next_global_index: 0,
-            current_decision_level: DecisionLevel(0),
+            current_decision_level: DecisionLevel::ZERO,
             package_assignments: FnvIndexMap::default(),
             prioritized_potential_packages: PriorityQueue::default(),
             outdated_priorities: FnvIndexSet::default(),
@@ -223,7 +259,7 @@ impl<DP: DependencyProvider> PartialSolution<DP> {
                 },
             }
         }
-        let new_idx = self.current_decision_level.0 as usize;
+        let new_idx = self.current_decision_level.get() as usize;
         self.current_decision_level = self.current_decision_level.increment();
         let (old_idx, _, pa) = self
             .package_assignments
@@ -311,7 +347,7 @@ impl<DP: DependencyProvider> PartialSolution<DP> {
         // TODO(konsti): Should we use `self.outdated_priorities` instead?
         let current_decision_level = self.current_decision_level;
         self.package_assignments
-            .get_range(self.current_decision_level.0 as usize..)
+            .get_range(self.current_decision_level.get() as usize..)
             .unwrap()
             .iter()
             .filter(move |(_, pa)| pa.highest_decision_level == current_decision_level)
@@ -353,7 +389,7 @@ impl<DP: DependencyProvider> PartialSolution<DP> {
     pub fn extract_solution(&self) -> impl Iterator<Item = (Id<DP::P>, DP::V)> + '_ {
         self.package_assignments
             .iter()
-            .take(self.current_decision_level.0 as usize)
+            .take(self.current_decision_level.get() as usize)
             .map(|(&p, pa)| match &pa.assignments_intersection {
                 AssignmentsIntersection::Decision {
                     decision_level: _,
@@ -366,7 +402,7 @@ impl<DP: DependencyProvider> PartialSolution<DP> {
                     for (id, assignment) in self
                         .package_assignments
                         .iter()
-                        .take(self.current_decision_level.0 as usize)
+                        .take(self.current_decision_level.get() as usize)
                     {
                         context.push_str(&format!(
                             " * {:?} {:?}\n",
@@ -375,7 +411,7 @@ impl<DP: DependencyProvider> PartialSolution<DP> {
                     }
                     panic!(
                         "Derivations in the Decision part. Decision level {}\n{}",
-                        self.current_decision_level.0, context
+                        self.current_decision_level.get(), context
                     )
                 }
             })
@@ -443,13 +479,13 @@ impl<DP: DependencyProvider> PartialSolution<DP> {
         let Some(decision_level) = self.package_assignments.get_index_of(&package) else {
             return Err(());
         };
-        let decision_level = DecisionLevel(decision_level as u32);
+        let decision_level = DecisionLevel::new(decision_level as u32);
         if decision_level > self.current_decision_level {
             return Err(());
         }
         debug!(
             "Package backtracking ot decision level {}",
-            decision_level.0
+            decision_level.get()
         );
         self.backtrack(decision_level);
         Ok(decision_level)
@@ -618,7 +654,7 @@ impl<DP: DependencyProvider> PartialSolution<DP> {
             .iter()
             .max_by_key(|(_p, (_, global_index, _))| global_index)
             .unwrap();
-        decision_level.max(DecisionLevel(1))
+        decision_level.max(DecisionLevel::new(1))
     }
 
     pub(crate) fn current_decision_level(&self) -> DecisionLevel {
@@ -632,7 +668,7 @@ impl<DP: DependencyProvider> PartialSolution<DP> {
         let idx_newer = pa
             .dated_derivations
             .as_slice()
-            .partition_point(|dd| dd.decision_level <= DecisionLevel(1));
+            .partition_point(|dd| dd.decision_level <= DecisionLevel::new(1));
         let idx = idx_newer.checked_sub(1)?;
         Some(&pa.dated_derivations[idx].accumulated_intersection)
     }

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -60,9 +60,7 @@ impl Debug for DecisionLevel {
 // The niche is the whole point: `Option<DecisionLevel>` must stay as small as a
 // bare `u32` so `core`'s contradicted-incompatibility map pays nothing for the
 // readability of `Vec<Option<DecisionLevel>>`.
-const _: () = assert!(
-    std::mem::size_of::<Option<DecisionLevel>>() == std::mem::size_of::<u32>()
-);
+const _: () = assert!(std::mem::size_of::<Option<DecisionLevel>>() == std::mem::size_of::<u32>());
 
 /// The partial solution contains all package assignments,
 /// organized by package and historically ordered.
@@ -411,7 +409,8 @@ impl<DP: DependencyProvider> PartialSolution<DP> {
                     }
                     panic!(
                         "Derivations in the Decision part. Decision level {}\n{}",
-                        self.current_decision_level.get(), context
+                        self.current_decision_level.get(),
+                        context
                     )
                 }
             })


### PR DESCRIPTION
## What

(This PR revives [#54](https://github.com/astral-sh/pubgrub/pull/54) by @RyanJamesStewart, addressing some of the feedback.)

`State::contradicted_incompatibilities` records the decision level at which each incompatibility was last found contradicted. The solver checks it in the inner `unit_propagation` loop before doing any further work for an incompatibility.

Incompatibility IDs are dense arena indices, so this replaces the `FxHashMap` with a typed dense vector indexed by the raw ID. Each slot is an `Option<DecisionLevel>`: `Some(level)` means the incompatibility is currently contradicted, while `None` means it is not. `DecisionLevel` stores its zero-based value plus one in a `NonZeroU32`, allowing `Option<DecisionLevel>` to remain four bytes without a hand-written sentinel.

## Why

The contradiction check runs many times per incompatibility per propagation round on conflict-heavy resolutions. A dense array lookup avoids hashing and probing on that hot path. An `IndexMap` could make the backtracking cleanup cheaper, but it would restore a hash lookup to the much hotter contradiction check, so the dense vector remains the better tradeoff for this workload.

## Performance

Core-pinned Criterion comparisons after the `Option<DecisionLevel>` change produced:

| Benchmark | Change (95% CI; median) |
|---|---:|
| `backtracking_singletons` | `[-28.729%, -28.472%]`; **-28.604%** |
| `backtracking_disjoint_versions` | `[-19.839%, -19.594%]`; **-19.714%** |
| `backtracking_ranges` | `[-3.593%, -2.838%]`; **-3.229%** |
| `large_case_u16_NumberVersion` | `[-5.120%, -4.888%]`; **-5.004%** |

A fresh current-head comparison against today's uv `main`, using uv's pinned pubgrub 0.3.3 and the `resolve_warm_airflow` benchmark, was statistically flat: 95% CI `[-2.59%, +2.71%]`, `p = 0.94`. The older reported `-2.71%` uv result does not reproduce on the current uv benchmark and is not claimed here.
