### PR TITLE
Store package incompatibilities in a dense IdMap

### DIFF
--- a/src/internal/arena.rs
+++ b/src/internal/arena.rs
@@ -66,6 +66,92 @@ impl<T> Id<T> {
     }
 }
 
+/// A map optimized for dense [`Id`] keys.
+///
+/// Values are stored at the raw index of their key. The map contains every id through the highest
+/// inserted id; inserting a later id fills skipped indices with `V::default()`.
+pub struct IdMap<K, V> {
+    data: Vec<V>,
+    _key: PhantomData<fn() -> K>,
+}
+
+impl<K, V: Clone> Clone for IdMap<K, V> {
+    fn clone(&self) -> Self {
+        Self {
+            data: self.data.clone(),
+            _key: PhantomData,
+        }
+    }
+}
+
+impl<K, V> Default for IdMap<K, V> {
+    fn default() -> Self {
+        Self {
+            data: Vec::new(),
+            _key: PhantomData,
+        }
+    }
+}
+
+impl<K, V> IdMap<K, V> {
+    /// Returns the value associated with `id`, if present.
+    #[inline]
+    pub fn get(&self, id: &Id<K>) -> Option<&V> {
+        self.data.get(id.into_raw())
+    }
+
+    /// Returns the mutable value associated with `id`, if present.
+    #[inline]
+    pub fn get_mut(&mut self, id: &Id<K>) -> Option<&mut V> {
+        self.data.get_mut(id.into_raw())
+    }
+
+    /// Sets the value associated with `id`.
+    #[inline]
+    pub fn set(&mut self, id: Id<K>, value: V)
+    where
+        V: Default,
+    {
+        let index = id.into_raw();
+        if index >= self.data.len() {
+            self.data.resize_with(index, V::default);
+            self.data.push(value);
+        } else {
+            self.data[index] = value;
+        }
+    }
+
+    #[inline]
+    pub(crate) fn get_or_insert_default(&mut self, id: Id<K>) -> &mut V
+    where
+        V: Default,
+    {
+        let index = id.into_raw();
+        if index >= self.data.len() {
+            self.data.resize_with(index + 1, V::default);
+        }
+        &mut self.data[index]
+    }
+}
+
+impl<K, V> Index<Id<K>> for IdMap<K, V> {
+    type Output = V;
+
+    #[inline]
+    fn index(&self, id: Id<K>) -> &Self::Output {
+        self.get(&id).expect("id is not present in map")
+    }
+}
+
+impl<K, V> Index<&Id<K>> for IdMap<K, V> {
+    type Output = V;
+
+    #[inline]
+    fn index(&self, id: &Id<K>) -> &Self::Output {
+        self.get(id).expect("id is not present in map")
+    }
+}
+
 /// Yet another index-based arena.
 ///
 /// An arena is a kind of simple grow-only allocator, backed by a `Vec`
@@ -171,5 +257,27 @@ impl<T: Hash + Eq> Index<Id<T>> for HashArena<T> {
     type Output = T;
     fn index(&self, id: Id<T>) -> &T {
         &self.data[id.raw as usize]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn id_map_fills_skipped_ids_with_default_values() {
+        let mut keys = Arena::new();
+        let first = keys.alloc(());
+        let second = keys.alloc(());
+        let mut map = IdMap::default();
+
+        map.set(second, 2);
+        assert_eq!(map.get(&first), Some(&0));
+        assert_eq!(map[second], 2);
+
+        *map.get_or_insert_default(first) = 1;
+        assert_eq!(map[first], 1);
+        map.set(first, 3);
+        assert_eq!(map[first], 3);
     }
 }

--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -8,8 +8,8 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use crate::internal::{
-    Arena, DecisionLevel, HashArena, Id, IncompDpId, IncompId, Incompatibility, PartialSolution,
-    Relation, SatisfierSearch, SmallVec,
+    Arena, DecisionLevel, HashArena, Id, IdMap, IncompDpId, IncompId, Incompatibility,
+    PartialSolution, Relation, SatisfierSearch, SmallVec,
 };
 use crate::{DependencyProvider, DerivationTree, Map, NoSolutionError, VersionSet};
 
@@ -127,8 +127,7 @@ pub struct State<DP: DependencyProvider> {
     root_version: DP::V,
 
     /// All incompatibilities indexed by package.
-    #[allow(clippy::type_complexity)]
-    pub incompatibilities: Map<Id<DP::P>, Vec<IncompDpId<DP>>>,
+    pub incompatibilities: IdMap<DP::P, Vec<IncompDpId<DP>>>,
 
     /// As an optimization, store the ids of incompatibilities that are already contradicted.
     ///
@@ -166,8 +165,8 @@ impl<DP: DependencyProvider> State<DP> {
             root_package,
             root_version.clone(),
         ));
-        let mut incompatibilities = Map::default();
-        incompatibilities.insert(root_package, vec![not_root_id]);
+        let mut incompatibilities = IdMap::default();
+        incompatibilities.set(root_package, vec![not_root_id]);
         Self {
             root_package,
             root_version,
@@ -489,8 +488,7 @@ impl<DP: DependencyProvider> State<DP> {
                 let new = self.incompatibility_store.alloc(merged);
                 for (pkg, _) in self.incompatibility_store[new].iter() {
                     self.incompatibilities
-                        .entry(pkg)
-                        .or_default()
+                        .get_or_insert_default(pkg)
                         .retain(|id| id != past);
                 }
                 *past = new;
@@ -503,7 +501,7 @@ impl<DP: DependencyProvider> State<DP> {
             if cfg!(debug_assertions) {
                 assert_ne!(term, &crate::term::Term::any());
             }
-            self.incompatibilities.entry(pkg).or_default().push(id);
+            self.incompatibilities.get_or_insert_default(pkg).push(id);
         }
     }
 

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -16,6 +16,6 @@ pub(crate) use small_map::SmallMap;
 pub(crate) use small_vec::SmallVec;
 
 // uv-specific additions
-pub use arena::Id;
+pub use arena::{Id, IdMap};
 pub use core::State;
 pub use incompatibility::{IncompId, Incompatibility, Kind};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,6 +242,6 @@ pub use version_ranges::Ranges as Range;
 pub use version_set::VersionSet;
 
 // uv-specific additions
-pub use internal::{Id, IncompId, Incompatibility, Kind, State};
+pub use internal::{Id, IdMap, IncompId, Incompatibility, Kind, State};
 
 mod internal;


### PR DESCRIPTION
## What

(This is a follow-up to [#56](https://github.com/astral-sh/pubgrub/pull/56), implementing the `IdMap<P, T>` suggestion from [#54](https://github.com/astral-sh/pubgrub/pull/54).)

`State::incompatibilities` maps package IDs to the incompatibilities that mention each package. Package IDs are dense arena indices, so this adds a typed `IdMap<K, V>` backed by a `Vec<V>` and uses it in place of the hash map.

Values are stored at the raw index of their key. Extending past the current end fills skipped IDs with `V::default()`; for incompatibility lists, the empty vector is the natural value for a package with no recorded incompatibilities. The API uses `set` rather than a map-like `insert -> Option<V>` because the dense representation is total through its highest initialized ID and does not track whether a default-filled slot was explicitly inserted.

## Why

The type system now distinguishes a vector used as a dense-key map from vectors used as ordinary sequences, while lookups avoid hashing and probing. The wrapper retains the `get` and indexing access patterns used by uv without exposing the raw vector or allowing package IDs for one arena to index another.

Local comparisons against #56 found no statistically significant change across the PubGrub backtracking benchmarks or uv's Jupyter resolver benchmarks. The Airflow resolver benchmark favored the dense map in both run orders, but absolute timings were noisy enough that this PR does not claim a speedup. The full workspace tests and doctests, Rust 1.92 tests, strict Clippy, and warning-free RustDoc all pass.
