### PR TITLE
Cache contradicted incompatibilities inline

### DIFF
--- a/src/internal/arena.rs
+++ b/src/internal/arena.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
-use std::ops::{Index, Range};
+use std::ops::{Index, IndexMut, Range};
 
 type FnvIndexSet<V> = indexmap::IndexSet<V, rustc_hash::FxBuildHasher>;
 
@@ -117,6 +117,12 @@ impl<T> Index<Id<T>> for Arena<T> {
     type Output = T;
     fn index(&self, id: Id<T>) -> &T {
         &self.data[id.raw as usize]
+    }
+}
+
+impl<T> IndexMut<Id<T>> for Arena<T> {
+    fn index_mut(&mut self, id: Id<T>) -> &mut Self::Output {
+        &mut self.data[id.raw as usize]
     }
 }
 

--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -85,7 +85,9 @@ impl<DP: DependencyProvider> State<DP> {
     }
 
     /// Add an incompatibility to the state.
-    pub fn add_incompatibility(&mut self, incompat: Incompatibility<DP::P, DP::VS, DP::M>) {
+    pub fn add_incompatibility(&mut self, mut incompat: Incompatibility<DP::P, DP::VS, DP::M>) {
+        // Cached contradictions are only valid in the state that recorded them.
+        incompat.reset_contradiction_cache();
         let id = self.incompatibility_store.alloc(incompat);
         self.merge_incompatibility(id);
     }

--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -4,7 +4,6 @@
 //! to write a functional PubGrub algorithm.
 
 use std::collections::HashSet as Set;
-use std::marker::PhantomData;
 use std::sync::Arc;
 
 use crate::internal::{
@@ -12,112 +11,6 @@ use crate::internal::{
     Relation, SatisfierSearch, SmallVec,
 };
 use crate::{DependencyProvider, DerivationTree, Map, NoSolutionError, VersionSet};
-
-/// Tracks, for each incompatibility, the decision level at which it was last found to be
-/// contradicted (if any).
-///
-/// Incompatibility ids are dense `u32` arena indices, so this is stored as a flat `Vec` indexed
-/// by the raw id, with `None` for "not currently contradicted", rather than a hash map. This
-/// makes the `is_contradicted` check on the hot `unit_propagation` path a bounds-checked array
-/// load instead of a hash lookup, which matters because that check runs many times per
-/// incompatibility per propagation round. `DecisionLevel` carries a niche, so each entry is
-/// `Option<DecisionLevel>` in 4 bytes, no wider than a bare id-to-level array would be.
-struct ContradictedIncompatibilities<DP: DependencyProvider> {
-    /// `levels[id]` is `Some(dl)` if the incompatibility was found contradicted at decision
-    /// level `dl`, and `None` if it is not currently contradicted.
-    levels: Vec<Option<DecisionLevel>>,
-    _provider: PhantomData<fn() -> DP>,
-}
-
-impl<DP: DependencyProvider> Clone for ContradictedIncompatibilities<DP> {
-    fn clone(&self) -> Self {
-        Self {
-            levels: self.levels.clone(),
-            _provider: PhantomData,
-        }
-    }
-}
-
-impl<DP: DependencyProvider> Default for ContradictedIncompatibilities<DP> {
-    fn default() -> Self {
-        Self {
-            levels: Vec::new(),
-            _provider: PhantomData,
-        }
-    }
-}
-
-impl<DP: DependencyProvider> ContradictedIncompatibilities<DP> {
-    /// Returns whether `id` is currently contradicted.
-    ///
-    /// IDs beyond the allocated slots have not been seen yet and therefore return `false`.
-    #[inline]
-    fn is_contradicted(&self, id: IncompDpId<DP>) -> bool {
-        matches!(self.levels.get(id.into_raw()), Some(Some(_)))
-    }
-
-    /// Records that `id` is contradicted at `decision_level`, growing the dense table as needed.
-    #[inline]
-    fn insert(&mut self, id: IncompDpId<DP>, decision_level: DecisionLevel) {
-        let idx = id.into_raw();
-        if idx >= self.levels.len() {
-            self.levels.resize(idx + 1, None);
-        }
-        self.levels[idx] = Some(decision_level);
-    }
-
-    /// Forget every entry recorded at a decision level strictly greater than `decision_level`.
-    #[inline]
-    fn retain_le(&mut self, decision_level: DecisionLevel) {
-        // `Option` orders `None` below every `Some(level)`. Therefore,
-        // `slot > Some(decision_level)` is true exactly for contradicted entries
-        // above the threshold and false for `None`.
-        let limit = Some(decision_level);
-        for slot in &mut self.levels {
-            if *slot > limit {
-                *slot = None;
-            }
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::{OfflineDependencyProvider, Ranges};
-
-    type TestProvider = OfflineDependencyProvider<&'static str, Ranges<u32>>;
-
-    #[test]
-    fn contradicted_incompatibilities_track_and_backtrack_levels() {
-        let mut packages = HashArena::new();
-        let root = packages.alloc("root");
-        let mut incompatibilities: Arena<Incompatibility<&str, Ranges<u32>, String>> = Arena::new();
-        let ids: [IncompDpId<TestProvider>; 3] =
-            std::array::from_fn(|_| incompatibilities.alloc(Incompatibility::not_root(root, 0)));
-
-        let mut contradicted = ContradictedIncompatibilities::<TestProvider>::default();
-        let statuses = |contradicted: &ContradictedIncompatibilities<TestProvider>| {
-            ids.map(|id| contradicted.is_contradicted(id))
-        };
-        assert_eq!(statuses(&contradicted), [false; 3]);
-
-        contradicted.insert(ids[2], DecisionLevel::new(3));
-
-        assert_eq!(contradicted.levels.len(), 3);
-        assert_eq!(statuses(&contradicted), [false, false, true]);
-
-        contradicted.insert(ids[0], DecisionLevel::new(1));
-        contradicted.insert(ids[1], DecisionLevel::new(2));
-        contradicted.retain_le(DecisionLevel::new(2));
-
-        assert_eq!(statuses(&contradicted), [true, true, false]);
-
-        contradicted.retain_le(DecisionLevel::ZERO);
-
-        assert_eq!(statuses(&contradicted), [false; 3]);
-    }
-}
 
 /// Current state of the PubGrub algorithm.
 #[derive(Clone)]
@@ -129,12 +22,6 @@ pub struct State<DP: DependencyProvider> {
     /// All incompatibilities indexed by package.
     #[allow(clippy::type_complexity)]
     pub incompatibilities: Map<Id<DP::P>, Vec<IncompDpId<DP>>>,
-
-    /// As an optimization, store the ids of incompatibilities that are already contradicted.
-    ///
-    /// For each one keep track of the decision level when it was found to be contradicted.
-    /// These will stay contradicted until we have backtracked beyond its associated decision level.
-    contradicted_incompatibilities: ContradictedIncompatibilities<DP>,
 
     /// All incompatibilities expressing dependencies,
     /// with common dependents merged.
@@ -172,7 +59,6 @@ impl<DP: DependencyProvider> State<DP> {
             root_package,
             root_version,
             incompatibilities,
-            contradicted_incompatibilities: ContradictedIncompatibilities::default(),
             partial_solution: PartialSolution::empty(),
             incompatibility_store,
             package_store,
@@ -285,8 +171,8 @@ impl<DP: DependencyProvider> State<DP> {
             // We only care about incompatibilities if it contains the current package.
             for &incompat_id in self.incompatibilities[&current_package].iter().rev() {
                 if self
-                    .contradicted_incompatibilities
-                    .is_contradicted(incompat_id)
+                    .partial_solution
+                    .is_contradicted(&self.incompatibility_store[incompat_id])
                 {
                     continue;
                 }
@@ -317,12 +203,12 @@ impl<DP: DependencyProvider> State<DP> {
                             &self.incompatibility_store,
                         );
                         // With the partial solution updated, the incompatibility is now contradicted.
-                        self.contradicted_incompatibilities
-                            .insert(incompat_id, self.partial_solution.current_decision_level());
+                        self.partial_solution
+                            .mark_contradicted(&mut self.incompatibility_store[incompat_id]);
                     }
                     Relation::Contradicted(_) => {
-                        self.contradicted_incompatibilities
-                            .insert(incompat_id, self.partial_solution.current_decision_level());
+                        self.partial_solution
+                            .mark_contradicted(&mut self.incompatibility_store[incompat_id]);
                     }
                     _ => {}
                 }
@@ -343,8 +229,8 @@ impl<DP: DependencyProvider> State<DP> {
                 );
                 // After conflict resolution and the partial solution update,
                 // the root cause incompatibility is now contradicted.
-                self.contradicted_incompatibilities
-                    .insert(root_cause, self.partial_solution.current_decision_level());
+                self.partial_solution
+                    .mark_contradicted(&mut self.incompatibility_store[root_cause]);
             }
         }
         // If there are no more changed packages, unit propagation is done.
@@ -439,9 +325,6 @@ impl<DP: DependencyProvider> State<DP> {
         decision_level: DecisionLevel,
     ) {
         self.partial_solution.backtrack(decision_level);
-        // Remove contradicted incompatibilities that depend on decisions we just backtracked away.
-        self.contradicted_incompatibilities
-            .retain_le(decision_level);
         if incompat_changed {
             self.merge_incompatibility(incompat);
         }
@@ -456,9 +339,6 @@ impl<DP: DependencyProvider> State<DP> {
     pub fn backtrack_package(&mut self, package: Id<DP::P>) -> Option<u32> {
         let base_decision_level = self.partial_solution.current_decision_level();
         let new_decision_level = self.partial_solution.backtrack_package(package).ok()?;
-        // Remove contradicted incompatibilities that depend on decisions we just backtracked away.
-        self.contradicted_incompatibilities
-            .retain_le(new_decision_level);
         Some(base_decision_level.get() - new_decision_level.get())
     }
 

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -287,6 +287,10 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
         };
     }
 
+    pub(crate) fn reset_contradiction_cache(&mut self) {
+        self.contradiction_info = ContradictionInfo::not_contradicted();
+    }
+
     /// Check if an incompatibility should mark the end of the algorithm
     /// because it satisfies the root package.
     pub(crate) fn is_terminal(&self, root_package: Id<P>, root_version: &VS::V) -> bool {

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -6,11 +6,38 @@
 use std::fmt::{Debug, Display};
 use std::sync::Arc;
 
-use crate::internal::{Arena, HashArena, Id, SmallMap};
+use crate::internal::{Arena, DecisionLevel, HashArena, Id, SmallMap};
 use crate::{
     DependencyProvider, DerivationTree, Derived, External, Map, Package, Set, Term, VersionSet,
     term,
 };
+
+#[derive(Debug, Clone)]
+struct ContradictionInfo {
+    /// The decision level where this incompatibility became contradicted.
+    decision_level: DecisionLevel,
+    /// The backtrack generation for that decision level.
+    backtrack_generation: u32,
+}
+
+impl ContradictionInfo {
+    fn not_contradicted() -> Self {
+        Self {
+            decision_level: DecisionLevel::MAX,
+            backtrack_generation: 0,
+        }
+    }
+
+    fn is_contradicted(&self, last_valid_decision_levels: &[DecisionLevel]) -> bool {
+        // The active generation has no backtrack target yet, so every contradiction recorded in
+        // it remains valid. Completed generations store the highest decision level that survived
+        // their first invalidating backtrack.
+        last_valid_decision_levels
+            .get(self.backtrack_generation as usize)
+            .map(|&level| self.decision_level <= level)
+            .unwrap_or(true)
+    }
+}
 
 /// An incompatibility is a set of terms for different packages
 /// that should never be satisfied all together.
@@ -32,6 +59,7 @@ pub struct Incompatibility<P: Package, VS: VersionSet, M: Eq + Clone + Debug + D
     package_terms: SmallMap<Id<P>, Term<VS>>,
     /// The reason for the incompatibility.
     pub kind: Kind<P, VS, M>,
+    contradiction_info: ContradictionInfo,
 }
 
 /// Type alias of unique identifiers for incompatibilities.
@@ -102,6 +130,7 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
                 Term::Negative(VS::singleton(version.clone())),
             )]),
             kind: Kind::NotRoot(package, version),
+            contradiction_info: ContradictionInfo::not_contradicted(),
         }
     }
 
@@ -114,6 +143,7 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
         Self {
             package_terms: SmallMap::One([(package, term)]),
             kind: Kind::NoVersions(package, set),
+            contradiction_info: ContradictionInfo::not_contradicted(),
         }
     }
 
@@ -127,6 +157,7 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
         Self {
             package_terms: SmallMap::One([(package, term)]),
             kind: Kind::Custom(package, set, metadata),
+            contradiction_info: ContradictionInfo::not_contradicted(),
         }
     }
 
@@ -137,6 +168,7 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
         Self {
             package_terms: SmallMap::One([(package, term)]),
             kind: Kind::Custom(package, set, metadata),
+            contradiction_info: ContradictionInfo::not_contradicted(),
         }
     }
 
@@ -153,6 +185,7 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
                 ])
             },
             kind: Kind::FromDependencyOf(package, versions, p2, set2),
+            contradiction_info: ContradictionInfo::not_contradicted(),
         }
     }
 
@@ -234,7 +267,24 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
         Self {
             package_terms,
             kind,
+            contradiction_info: ContradictionInfo::not_contradicted(),
         }
+    }
+
+    pub(crate) fn is_contradicted(&self, last_valid_decision_levels: &[DecisionLevel]) -> bool {
+        self.contradiction_info
+            .is_contradicted(last_valid_decision_levels)
+    }
+
+    pub(crate) fn mark_contradicted(
+        &mut self,
+        decision_level: DecisionLevel,
+        backtrack_generation: u32,
+    ) {
+        self.contradiction_info = ContradictionInfo {
+            decision_level,
+            backtrack_generation,
+        };
     }
 
     /// Check if an incompatibility should mark the end of the algorithm
@@ -404,6 +454,32 @@ pub(crate) mod tests {
     use crate::term::tests::strategy as term_strat;
     use crate::{OfflineDependencyProvider, Ranges};
 
+    #[test]
+    fn contradiction_info_tracks_backtrack_generations() {
+        let current_generation = ContradictionInfo {
+            decision_level: DecisionLevel::new(3),
+            backtrack_generation: 1,
+        };
+
+        // A generation without a recorded backtrack target is still active.
+        assert!(current_generation.is_contradicted(&[DecisionLevel::ZERO]));
+        // Backtracking below the contradiction's decision level invalidates it.
+        assert!(!current_generation.is_contradicted(&[DecisionLevel::ZERO, DecisionLevel::new(2)]));
+        // Backtracking to or above that decision level preserves it.
+        assert!(current_generation.is_contradicted(&[DecisionLevel::ZERO, DecisionLevel::new(3)]));
+
+        let later_generation = ContradictionInfo {
+            decision_level: DecisionLevel::new(5),
+            backtrack_generation: 2,
+        };
+        assert!(later_generation.is_contradicted(&[DecisionLevel::ZERO, DecisionLevel::new(3)]));
+        assert!(!later_generation.is_contradicted(&[
+            DecisionLevel::ZERO,
+            DecisionLevel::new(3),
+            DecisionLevel::new(4),
+        ]));
+    }
+
     proptest! {
 
         /// For any three different packages p1, p2 and p3,
@@ -422,12 +498,14 @@ pub(crate) mod tests {
             let p3 = package_store.alloc("p3");
             let i1 = store.alloc(Incompatibility {
                 package_terms: SmallMap::Two([(p1, t1.clone()), (p2, t2.negate())]),
-                kind: Kind::<_, _, String>::FromDependencyOf(p1, Ranges::full(), p2, Ranges::full())
+                kind: Kind::<_, _, String>::FromDependencyOf(p1, Ranges::full(), p2, Ranges::full()),
+                contradiction_info: ContradictionInfo::not_contradicted(),
             });
 
             let i2 = store.alloc(Incompatibility {
                 package_terms: SmallMap::Two([(p2, t2), (p3, t3.clone())]),
-                kind: Kind::<_, _, String>::FromDependencyOf(p2, Ranges::full(), p3, Ranges::full())
+                kind: Kind::<_, _, String>::FromDependencyOf(p2, Ranges::full(), p3, Ranges::full()),
+                contradiction_info: ContradictionInfo::not_contradicted(),
             });
 
             let mut i3 = Map::default();

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -13,14 +13,14 @@ use crate::{
 };
 
 #[derive(Debug, Clone)]
-struct ContradictionInfo {
+struct ContradictionCache {
     /// The decision level where this incompatibility became contradicted.
     decision_level: DecisionLevel,
     /// The backtrack generation for that decision level.
     backtrack_generation: u32,
 }
 
-impl ContradictionInfo {
+impl ContradictionCache {
     fn not_contradicted() -> Self {
         Self {
             decision_level: DecisionLevel::MAX,
@@ -59,7 +59,7 @@ pub struct Incompatibility<P: Package, VS: VersionSet, M: Eq + Clone + Debug + D
     package_terms: SmallMap<Id<P>, Term<VS>>,
     /// The reason for the incompatibility.
     pub kind: Kind<P, VS, M>,
-    contradiction_info: ContradictionInfo,
+    contradiction_cache: ContradictionCache,
 }
 
 /// Type alias of unique identifiers for incompatibilities.
@@ -130,7 +130,7 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
                 Term::Negative(VS::singleton(version.clone())),
             )]),
             kind: Kind::NotRoot(package, version),
-            contradiction_info: ContradictionInfo::not_contradicted(),
+            contradiction_cache: ContradictionCache::not_contradicted(),
         }
     }
 
@@ -143,7 +143,7 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
         Self {
             package_terms: SmallMap::One([(package, term)]),
             kind: Kind::NoVersions(package, set),
-            contradiction_info: ContradictionInfo::not_contradicted(),
+            contradiction_cache: ContradictionCache::not_contradicted(),
         }
     }
 
@@ -157,7 +157,7 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
         Self {
             package_terms: SmallMap::One([(package, term)]),
             kind: Kind::Custom(package, set, metadata),
-            contradiction_info: ContradictionInfo::not_contradicted(),
+            contradiction_cache: ContradictionCache::not_contradicted(),
         }
     }
 
@@ -168,7 +168,7 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
         Self {
             package_terms: SmallMap::One([(package, term)]),
             kind: Kind::Custom(package, set, metadata),
-            contradiction_info: ContradictionInfo::not_contradicted(),
+            contradiction_cache: ContradictionCache::not_contradicted(),
         }
     }
 
@@ -185,7 +185,7 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
                 ])
             },
             kind: Kind::FromDependencyOf(package, versions, p2, set2),
-            contradiction_info: ContradictionInfo::not_contradicted(),
+            contradiction_cache: ContradictionCache::not_contradicted(),
         }
     }
 
@@ -267,12 +267,12 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
         Self {
             package_terms,
             kind,
-            contradiction_info: ContradictionInfo::not_contradicted(),
+            contradiction_cache: ContradictionCache::not_contradicted(),
         }
     }
 
     pub(crate) fn is_contradicted(&self, last_valid_decision_levels: &[DecisionLevel]) -> bool {
-        self.contradiction_info
+        self.contradiction_cache
             .is_contradicted(last_valid_decision_levels)
     }
 
@@ -281,14 +281,14 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
         decision_level: DecisionLevel,
         backtrack_generation: u32,
     ) {
-        self.contradiction_info = ContradictionInfo {
+        self.contradiction_cache = ContradictionCache {
             decision_level,
             backtrack_generation,
         };
     }
 
     pub(crate) fn reset_contradiction_cache(&mut self) {
-        self.contradiction_info = ContradictionInfo::not_contradicted();
+        self.contradiction_cache = ContradictionCache::not_contradicted();
     }
 
     /// Check if an incompatibility should mark the end of the algorithm
@@ -459,8 +459,8 @@ pub(crate) mod tests {
     use crate::{OfflineDependencyProvider, Ranges};
 
     #[test]
-    fn contradiction_info_tracks_backtrack_generations() {
-        let current_generation = ContradictionInfo {
+    fn contradiction_cache_tracks_backtrack_generations() {
+        let current_generation = ContradictionCache {
             decision_level: DecisionLevel::new(3),
             backtrack_generation: 1,
         };
@@ -472,7 +472,7 @@ pub(crate) mod tests {
         // Backtracking to or above that decision level preserves it.
         assert!(current_generation.is_contradicted(&[DecisionLevel::ZERO, DecisionLevel::new(3)]));
 
-        let later_generation = ContradictionInfo {
+        let later_generation = ContradictionCache {
             decision_level: DecisionLevel::new(5),
             backtrack_generation: 2,
         };
@@ -503,13 +503,13 @@ pub(crate) mod tests {
             let i1 = store.alloc(Incompatibility {
                 package_terms: SmallMap::Two([(p1, t1.clone()), (p2, t2.negate())]),
                 kind: Kind::<_, _, String>::FromDependencyOf(p1, Ranges::full(), p2, Ranges::full()),
-                contradiction_info: ContradictionInfo::not_contradicted(),
+                contradiction_cache: ContradictionCache::not_contradicted(),
             });
 
             let i2 = store.alloc(Incompatibility {
                 package_terms: SmallMap::Two([(p2, t2), (p3, t3.clone())]),
                 kind: Kind::<_, _, String>::FromDependencyOf(p2, Ranges::full(), p3, Ranges::full()),
-                contradiction_info: ContradictionInfo::not_contradicted(),
+                contradiction_cache: ContradictionCache::not_contradicted(),
             });
 
             let mut i3 = Map::default();

--- a/src/internal/partial_solution.rs
+++ b/src/internal/partial_solution.rs
@@ -24,15 +24,15 @@ type FnvIndexSet<T> = indexmap::IndexSet<T, BuildHasherDefault<FxHasher>>;
 ///
 /// The logical level is zero-based, but it is stored as `level + 1` in a
 /// `NonZeroU32` so that `Option<DecisionLevel>` fits in the same 4 bytes as a
-/// bare `u32`, with `None` occupying the all-zero niche. That lets `core`
-/// track contradicted incompatibilities as a compact `Vec<Option<DecisionLevel>>`
-/// instead of a `Vec<u32>` with a hand-rolled sentinel.
+/// bare `u32`, with `None` occupying the all-zero niche.
 #[derive(Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub(crate) struct DecisionLevel(NonZeroU32);
 
 impl DecisionLevel {
     /// Decision level zero: no decisions have been made yet.
     pub(crate) const ZERO: DecisionLevel = DecisionLevel(NonZeroU32::MIN);
+    /// Sentinel greater than any decision level the solver can reach.
+    pub(crate) const MAX: DecisionLevel = DecisionLevel(NonZeroU32::MAX);
 
     /// Build a `DecisionLevel` from its zero-based logical value.
     pub(crate) fn new(level: u32) -> Self {
@@ -58,9 +58,7 @@ impl Debug for DecisionLevel {
     }
 }
 
-// The niche is the whole point: `Option<DecisionLevel>` must stay as small as a
-// bare `u32` so `core`'s contradicted-incompatibility map pays nothing for the
-// readability of `Vec<Option<DecisionLevel>>`.
+// Preserve the niche so `Option<DecisionLevel>` stays as small as a bare `u32`.
 const _: () = assert!(std::mem::size_of::<Option<DecisionLevel>>() == std::mem::size_of::<u32>());
 
 /// The partial solution contains all package assignments,
@@ -100,8 +98,9 @@ pub struct PartialSolution<DP: DependencyProvider> {
     /// Packages whose derivations changed since the last time `prioritize` was called and need
     /// their priorities to be updated.
     outdated_priorities: FnvIndexSet<Id<DP::P>>,
-    /// Whether we have never backtracked, to enable fast path optimizations.
-    has_ever_backtracked: bool,
+    /// For each completed backtrack generation, the highest decision level that remains valid.
+    /// The active generation is represented by the missing entry after the end of this vector.
+    last_valid_decision_levels: Vec<DecisionLevel>,
 }
 
 /// A package assignment is either a decision or a list of (accumulated) derivations without a
@@ -208,8 +207,25 @@ impl<DP: DependencyProvider> PartialSolution<DP> {
             package_assignments: FnvIndexMap::default(),
             prioritized_potential_packages: PriorityQueue::default(),
             outdated_priorities: FnvIndexSet::default(),
-            has_ever_backtracked: false,
+            last_valid_decision_levels: vec![DecisionLevel::ZERO],
         }
+    }
+
+    pub(crate) fn is_contradicted(
+        &self,
+        incompatibility: &Incompatibility<DP::P, DP::VS, DP::M>,
+    ) -> bool {
+        incompatibility.is_contradicted(&self.last_valid_decision_levels)
+    }
+
+    pub(crate) fn mark_contradicted(
+        &self,
+        incompatibility: &mut Incompatibility<DP::P, DP::VS, DP::M>,
+    ) {
+        incompatibility.mark_contradicted(
+            self.current_decision_level,
+            self.last_valid_decision_levels.len() as u32,
+        );
     }
 
     pub(crate) fn display<'a>(&'a self, package_store: &'a HashArena<DP::P>) -> impl Display + 'a {
@@ -466,7 +482,14 @@ impl<DP: DependencyProvider> PartialSolution<DP> {
                 true
             }
         });
-        self.has_ever_backtracked = true;
+
+        // Close the active generation, then lower every generation invalidated by this backtrack
+        // to the new highest valid decision level.
+        self.last_valid_decision_levels.push(DecisionLevel::MAX);
+        let index = self
+            .last_valid_decision_levels
+            .partition_point(|&level| level <= decision_level);
+        self.last_valid_decision_levels[index..].fill(decision_level);
     }
 
     /// Backtrack the partial solution before a particular package was selected.
@@ -506,7 +529,7 @@ impl<DP: DependencyProvider> PartialSolution<DP> {
         new_incompatibilities: std::ops::Range<IncompId<DP::P, DP::VS, DP::M>>,
         store: &Arena<Incompatibility<DP::P, DP::VS, DP::M>>,
     ) -> Option<IncompId<DP::P, DP::VS, DP::M>> {
-        if !self.has_ever_backtracked {
+        if self.last_valid_decision_levels.len() == 1 {
             // Fast path: Nothing has yet gone wrong during this resolution. This call is unlikely to be the first problem.
             // So let's live with a little bit of risk and add the decision without checking the dependencies.
             // The worst that can happen is we will have to do a full backtrack which only removes this one decision.

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,12 +1,45 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use pubgrub::{
-    Dependencies, DependencyProvider, OfflineDependencyProvider, Package,
-    PackageResolutionStatistics, PubGrubError, Ranges, VersionSet, resolve,
+    Dependencies, DependencyProvider, Incompatibility, OfflineDependencyProvider, Package,
+    PackageResolutionStatistics, PubGrubError, Ranges, State, VersionSet, resolve,
 };
 use std::convert::Infallible;
 
 type NumVS = Ranges<u32>;
+
+#[test]
+fn cloned_incompatibility_does_not_reuse_contradiction_cache() {
+    type Provider = OfflineDependencyProvider<String, NumVS>;
+
+    let mut base: State<Provider> = State::init("root".to_string(), 0);
+    base.unit_propagation(base.root_package).unwrap();
+    base.add_package_version_dependencies(
+        base.root_package,
+        0,
+        [("foo".to_string(), Ranges::full())],
+    );
+    base.unit_propagation(base.root_package).unwrap();
+    let foo = base.package_store.alloc("foo".to_string());
+
+    let mut source = base.clone();
+    source.add_package_version_dependencies(foo, 2, []);
+    source.add_incompatibility(Incompatibility::custom_version(
+        foo,
+        1,
+        "foo 1 is unavailable".to_string(),
+    ));
+    assert!(source.unit_propagation(foo).unwrap().is_empty());
+    let incompatibility_id = *source.incompatibilities[&foo].last().unwrap();
+    let incompatibility = source.incompatibility_store[incompatibility_id].clone();
+
+    let mut target = base;
+    target.add_package_version_dependencies(foo, 1, []);
+    target.add_incompatibility(incompatibility);
+
+    let conflicts = target.unit_propagation(foo).unwrap();
+    assert!(!conflicts.is_empty());
+}
 
 #[test]
 fn same_result_on_repeated_runs() {


### PR DESCRIPTION
This ports x-hgg-x's [contradiction-cache optimization](https://github.com/pubgrub-rs/pubgrub/commit/5ce70ea5c34040d0eeca6b461b01037829a1c486) from #274 onto the current generic solver without taking the version-set representation changes from that experiment.

Previously, we kept contradicted incompatibilities in a separate hash map. Unit propagation hashed every incompatibility ID to consult that cache, and each backtrack scanned the map to discard entries that no longer applied.

This change stores the contradiction decision level and backtrack generation directly on each incompatibility. The partial solution records the highest surviving decision level for completed backtrack generations, so cache checks are direct arena accesses and backtracking invalidates prior entries without scanning a hash map. The public solver and version-set APIs are unchanged.

## Performance

Local CodSpeed CPU-simulation results for this exact diff against `a8ea393`:

| PubGrub benchmark | Baseline | This PR | Change |
| --- | ---: | ---: | ---: |
| `backtracking_singletons` | 4.41 s | 3.54 s | 19.7% faster |
| `backtracking_disjoint_versions` | 2.29 s | 2.01 s | 12.2% faster |
| `backtracking_ranges` | 1.89 s | 1.88 s | 0.5% faster |
| `large_case_u16_NumberVersion.ron` | 24.92 ms | 23.73 ms | 4.8% faster |
| `sudoku-easy` | 4.81 ms | 4.38 ms | 8.9% faster |
| `sudoku-hard` | 5.13 ms | 5.05 ms | 1.6% faster |

PubGrub reports: baseline ([backtracking](https://app.codspeed.io/astral-sh/pubgrub/runs/6a411ed36c85028ff4704fa7), [large case](https://app.codspeed.io/astral-sh/pubgrub/runs/6a411ee38715559a9f08580d), [Sudoku](https://app.codspeed.io/astral-sh/pubgrub/runs/6a411ef36c85028ff4704faf)) and this PR ([backtracking](https://app.codspeed.io/astral-sh/pubgrub/runs/6a413c03577a7b572671a225), [large case](https://app.codspeed.io/astral-sh/pubgrub/runs/6a413c17577a7b572671a226), [Sudoku](https://app.codspeed.io/astral-sh/pubgrub/runs/6a413c2a577a7b572671a228)).

I also patched this exact PubGrub checkout into uv at `cfa5ca8122dbdf9cc3950724500a882823102435`:

| uv benchmark | Baseline | This PR | Change |
| --- | ---: | ---: | ---: |
| `resolve_warm_jupyter` | 80.32 ms | 79.49 ms | 1.0% faster |
| `resolve_warm_jupyter_universal` | 203.64 ms | 203.59 ms | effectively unchanged |

uv reports: [baseline](https://app.codspeed.io/astral-sh/uv/runs/6a4121c48715559a9f085814) and [this PR](https://app.codspeed.io/astral-sh/uv/runs/6a413ca6577a7b572671a231). The Airflow fixture was excluded because its build-backend subprocess traps under the local Valgrind simulator.

The full all-features test suite, Clippy with warnings denied, formatting checks, and private-item documentation all pass.
