### PR TITLE
Run CodSpeed benchmarks on main

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -3,7 +3,7 @@ name: Benchmarks (CodSpeed)
 on:
   push:
     branches:
-      - dev
+      - main
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
CodSpeed compares pull request measurements against the latest benchmark run from the base branch. This repository's default branch is `main`, but the benchmark workflow currently runs on pushes to `dev` only, so `main` has no baseline and pull request benchmarks are reported as new.
