### PR TITLE
Expose double-ended range iteration

### DIFF
--- a/version-ranges/src/lib.rs
+++ b/version-ranges/src/lib.rs
@@ -1387,20 +1387,6 @@ pub mod tests {
     }
 
     #[test]
-    fn iter_is_double_ended() {
-        let range = Ranges::from_iter([(Included(1), Excluded(2)), (Included(3), Excluded(4))]);
-
-        assert_eq!(
-            range
-                .iter()
-                .rev()
-                .map(|(start, end)| (*start, *end))
-                .collect::<Vec<_>>(),
-            [(Included(3), Excluded(4)), (Included(1), Excluded(2))]
-        );
-    }
-
-    #[test]
     fn contains_many_can_take_owned() {
         let range: Ranges<u8> = Ranges::singleton(1);
         let versions = vec![1, 2, 3];

--- a/version-ranges/src/lib.rs
+++ b/version-ranges/src/lib.rs
@@ -852,7 +852,7 @@ impl<V: Ord + Clone> Ranges<V> {
     }
 
     /// Iterate over the parts of the range.
-    pub fn iter(&self) -> impl Iterator<Item = (&Bound<V>, &Bound<V>)> {
+    pub fn iter(&self) -> impl DoubleEndedIterator<Item = (&Bound<V>, &Bound<V>)> {
         self.segments.iter().map(|(start, end)| (start, end))
     }
 }
@@ -1384,6 +1384,20 @@ pub mod tests {
             let actual =  Ranges::from_iter(segments.clone());
             assert_eq!(expected, actual, "{segments:?}");
         }
+    }
+
+    #[test]
+    fn iter_is_double_ended() {
+        let range = Ranges::from_iter([(Included(1), Excluded(2)), (Included(3), Excluded(4))]);
+
+        assert_eq!(
+            range
+                .iter()
+                .rev()
+                .map(|(start, end)| (*start, *end))
+                .collect::<Vec<_>>(),
+            [(Included(3), Excluded(4)), (Included(1), Excluded(2))]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`Ranges::iter` returns a mapped slice iterator that is already double-ended, but its opaque return type only exposes `Iterator`. Callers that need reverse borrowed traversal therefore have to materialize the segments.

This exposes `DoubleEndedIterator` in the return type, allowing callers to traverse borrowed range segments in either direction without cloning or allocating while preserving existing forward iteration.

This unblocks allocation-free descending range traversal in astral-sh/uv#20026.
