### PR TITLE
Index merged dependencies by range hash

### DIFF
--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -4,13 +4,52 @@
 //! to write a functional PubGrub algorithm.
 
 use std::collections::HashSet as Set;
+use std::hash::{BuildHasher, Hash};
 use std::sync::Arc;
 
 use crate::internal::{
     Arena, DecisionLevel, HashArena, Id, IncompDpId, IncompId, Incompatibility, PartialSolution,
     Relation, SatisfierSearch, SmallVec,
 };
-use crate::{DependencyProvider, DerivationTree, Map, NoSolutionError, VersionSet};
+use crate::{DependencyProvider, DerivationTree, Map, NoSolutionError, Package, VersionSet};
+
+#[derive(Clone)]
+struct MergedDependencies<P: Package, I> {
+    buckets: Map<DependencyKey<P>, SmallVec<I>>,
+}
+
+impl<P: Package, I> Default for MergedDependencies<P, I> {
+    fn default() -> Self {
+        Self {
+            buckets: Map::default(),
+        }
+    }
+}
+
+impl<P: Package, I> MergedDependencies<P, I> {
+    fn bucket(
+        &mut self,
+        dependent: Id<P>,
+        dependency: Id<P>,
+        range: &impl Hash,
+    ) -> &mut SmallVec<I> {
+        let range_hash = self.buckets.hasher().hash_one(range);
+        self.buckets
+            .entry(DependencyKey {
+                dependent,
+                dependency,
+                range_hash,
+            })
+            .or_default()
+    }
+}
+
+#[derive(Clone, Copy, Eq, Hash, PartialEq)]
+struct DependencyKey<P: Package> {
+    dependent: Id<P>,
+    dependency: Id<P>,
+    range_hash: u64,
+}
 
 /// Current state of the PubGrub algorithm.
 #[derive(Clone)]
@@ -23,10 +62,8 @@ pub struct State<DP: DependencyProvider> {
     #[allow(clippy::type_complexity)]
     pub incompatibilities: Map<Id<DP::P>, Vec<IncompDpId<DP>>>,
 
-    /// All incompatibilities expressing dependencies,
-    /// with common dependents merged.
-    #[allow(clippy::type_complexity)]
-    merged_dependencies: Map<(Id<DP::P>, Id<DP::P>), SmallVec<IncompDpId<DP>>>,
+    /// All incompatibilities expressing dependencies, with common dependents merged.
+    merged_dependencies: MergedDependencies<DP::P, IncompDpId<DP>>,
 
     /// Partial solution.
     pub partial_solution: PartialSolution<DP>,
@@ -63,7 +100,7 @@ impl<DP: DependencyProvider> State<DP> {
             incompatibility_store,
             package_store,
             unit_propagation_buffer: SmallVec::Empty,
-            merged_dependencies: Map::default(),
+            merged_dependencies: MergedDependencies::default(),
         }
     }
 
@@ -360,25 +397,29 @@ impl<DP: DependencyProvider> State<DP> {
     /// We could collapse them into { foo (1.0.0 ∪ 1.1.0), not bar ^1.0.0 }
     /// without having to check the existence of other versions though.
     fn merge_incompatibility(&mut self, mut id: IncompDpId<DP>) {
-        if let Some((p1, p2)) = self.incompatibility_store[id].as_dependency() {
-            // If we are a dependency, there's a good chance we can be merged with a previous dependency
-            let deps_lookup = self.merged_dependencies.entry((p1, p2)).or_default();
-            if let Some((past, merged)) = deps_lookup.as_mut_slice().iter_mut().find_map(|past| {
-                self.incompatibility_store[id]
-                    .merge_dependents(&self.incompatibility_store[*past])
-                    .map(|m| (past, m))
-            }) {
-                let new = self.incompatibility_store.alloc(merged);
-                for (pkg, _) in self.incompatibility_store[new].iter() {
-                    self.incompatibilities
-                        .entry(pkg)
-                        .or_default()
-                        .retain(|id| id != past);
+        if let Some((p1, p2, dependency_range)) = self.incompatibility_store[id].as_dependency() {
+            // Self-dependencies cannot be merged.
+            if p1 != p2 {
+                let deps_lookup = self.merged_dependencies.bucket(p1, p2, dependency_range);
+                if let Some((past, merged)) =
+                    deps_lookup.as_mut_slice().iter_mut().find_map(|past| {
+                        self.incompatibility_store[id]
+                            .merge_dependents(&self.incompatibility_store[*past])
+                            .map(|merged| (past, merged))
+                    })
+                {
+                    let new = self.incompatibility_store.alloc(merged);
+                    for (pkg, _) in self.incompatibility_store[new].iter() {
+                        self.incompatibilities
+                            .entry(pkg)
+                            .or_default()
+                            .retain(|id| id != past);
+                    }
+                    *past = new;
+                    id = new;
+                } else {
+                    deps_lookup.push(id);
                 }
-                *past = new;
-                id = new;
-            } else {
-                deps_lookup.push(id);
             }
         }
         for (pkg, term) in self.incompatibility_store[id].iter() {
@@ -427,5 +468,79 @@ impl<DP: DependencyProvider> State<DP> {
         }
         // Now the user can refer to the entire tree from its root.
         Arc::into_inner(precomputed.remove(&incompat).unwrap()).unwrap()
+    }
+}
+
+#[cfg(test)]
+mod dependency_merge_tests {
+    use std::fmt::{self, Display};
+    use std::hash::{Hash, Hasher};
+
+    use crate::{OfflineDependencyProvider, Ranges, VersionSet};
+
+    use super::State;
+
+    #[test]
+    fn merge_dependencies_with_hash_collisions() {
+        let mut state: State<OfflineDependencyProvider<&str, CollidingRanges>> =
+            State::init("root", 0);
+        let package = state.package_store.alloc("package");
+
+        // Alternate two pairs of constraints so equal ranges recur non-adjacently, while every
+        // range shares the same hash.
+        for version in 0..10 {
+            let first = (version % 2) * 2;
+            state.add_incompatibility_from_dependencies(
+                package,
+                version,
+                [
+                    ("dependency", CollidingRanges::singleton(first)),
+                    ("dependency", CollidingRanges::singleton(first + 1)),
+                ],
+            );
+        }
+
+        let dependency = state.package_store.alloc("dependency");
+        assert_eq!(state.incompatibilities[&package].len(), 4);
+        assert_eq!(state.incompatibilities[&dependency].len(), 4);
+    }
+
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    struct CollidingRanges(Ranges<u32>);
+
+    impl Display for CollidingRanges {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            Display::fmt(&self.0, f)
+        }
+    }
+
+    impl Hash for CollidingRanges {
+        fn hash<H: Hasher>(&self, state: &mut H) {
+            0u8.hash(state);
+        }
+    }
+
+    impl VersionSet for CollidingRanges {
+        type V = u32;
+
+        fn empty() -> Self {
+            Self(Ranges::empty())
+        }
+
+        fn singleton(v: Self::V) -> Self {
+            Self(Ranges::singleton(v))
+        }
+
+        fn complement(&self) -> Self {
+            Self(self.0.complement())
+        }
+
+        fn intersection(&self, other: &Self) -> Self {
+            Self(self.0.intersection(&other.0))
+        }
+
+        fn contains(&self, v: &Self::V) -> bool {
+            self.0.contains(v)
+        }
     }
 }

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -189,9 +189,9 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
         }
     }
 
-    pub(crate) fn as_dependency(&self) -> Option<(Id<P>, Id<P>)> {
+    pub(crate) fn as_dependency(&self) -> Option<(Id<P>, Id<P>, &VS)> {
         match &self.kind {
-            Kind::FromDependencyOf(p1, _, p2, _) => Some((*p1, *p2)),
+            Kind::FromDependencyOf(p1, _, p2, range) => Some((*p1, *p2, range)),
             _ => None,
         }
     }
@@ -210,11 +210,11 @@ impl<P: Package, VS: VersionSet, M: Eq + Clone + Debug + Display> Incompatibilit
         debug_assert!(self.as_dependency().is_some());
         // Check that both incompatibilities are of the shape p1 depends on p2,
         // with the same p1 and p2.
-        let self_pkgs = self.as_dependency()?;
-        if self_pkgs != other.as_dependency()? {
+        let (p1, p2, _) = self.as_dependency()?;
+        let (other_p1, other_p2, _) = other.as_dependency()?;
+        if (p1, p2) != (other_p1, other_p2) {
             return None;
         }
-        let (p1, p2) = self_pkgs;
         // We ignore self-dependencies. They are always either trivially true or trivially false,
         // as the package version implies whether the constraint will always be fulfilled or always
         // violated.

--- a/src/version_set.rs
+++ b/src/version_set.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 use std::fmt::{Debug, Display};
+use std::hash::Hash;
 
 use crate::Ranges;
 
@@ -11,13 +12,13 @@ use crate::Ranges;
 /// The methods with default implementations can be overwritten for better performance, but their
 /// output must be equal to the default implementation.
 ///
-/// # Equality
+/// # Equality and hashing
 ///
-/// It is important that the `Eq` trait is implemented so that if two sets contain the same
-/// versions, they are equal under `Eq`. In particular, you can only use `#[derive(Eq, PartialEq)]`
-/// if `Eq` is strictly equivalent to the structural equality, i.e. if version sets are always
-/// stored in a canonical representations. Such problems may arise if your implementations of
-/// `complement()` and `intersection()` do not return canonical representations.
+/// It is important that the `Eq` and `Hash` traits are implemented so that if two sets contain the
+/// same versions, they are equal under `Eq` and produce the same hash. In particular, you can only
+/// derive these traits if equality is strictly equivalent to structural equality, i.e. if version
+/// sets are always stored in canonical representations. Such problems may arise if your
+/// implementations of `complement()` and `intersection()` do not return canonical representations.
 ///
 /// For example, `>=1,<4 || >=2,<5` and `>=1,<4 || >=3,<5` are equal, because they can both be
 /// normalized to `>=1,<5`.
@@ -26,7 +27,7 @@ use crate::Ranges;
 /// is about upholding the mathematical properties of set operations, assuming all versions are
 /// possible. This is required for the solver to determine the relationship of version sets to each
 /// other.
-pub trait VersionSet: Debug + Display + Clone + Eq {
+pub trait VersionSet: Debug + Display + Clone + Eq + Hash {
     /// Version type associated with the sets manipulated.
     type V: Debug + Display + Clone + Ord;
 
@@ -80,7 +81,7 @@ pub trait VersionSet: Debug + Display + Clone + Eq {
 }
 
 /// [`Ranges`] contains optimized implementations of all operations.
-impl<T: Debug + Display + Clone + Eq + Ord> VersionSet for Ranges<T> {
+impl<T: Debug + Display + Clone + Eq + Ord + Hash> VersionSet for Ranges<T> {
     type V = T;
 
     fn empty() -> Self {


### PR DESCRIPTION
## Summary

PubGrub merges identical dependency constraints from different package versions into a single incompatibility. Previously, each new dependency scanned every historical group for the same package pair, so workloads with many distinct ranges performed quadratic insertion work. Restricting the lookup to adjacent versions bounds that scan, but loses merging for recurring non-adjacent constraints and can grow the incompatibility lists used during backtracking.

This change requires `VersionSet` to implement `Hash` and indexes merge candidates by the dependent package, dependency package, and dependency-range hash. Each hash bucket still checks range equality through `merge_dependents`, so collisions are safe and historical merging behavior is preserved without cloning version sets into map keys. Self-dependencies bypass the index because they cannot be merged.

The built-in `Ranges<V>` implementation now requires `V: Hash`. Regression coverage exercises repeated constraints, alternating non-adjacent constraints, and deliberate hash collisions; the full locked test suite, strict Clippy, formatting, and diff checks pass.
