### PR TITLE
Fuse version-set relation checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "astral-version-ranges"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "proptest",
  "ron",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ priority-queue = "2.3.1"
 rustc-hash = "^2.1.1"
 serde = { version = "1.0.219", features = ["derive"], optional = true }
 thiserror = "2.0"
-version-ranges = { version = "0.1.0", package = "astral-version-ranges", path = "version-ranges" }
+version-ranges = { version = "0.1.5", package = "astral-version-ranges", path = "version-ranges" }
 
 [dev-dependencies]
 criterion = { version = "4.7.0", package = "codspeed-criterion-compat" }
@@ -45,7 +45,7 @@ cc = "1.2.40"
 proptest = "1.6.0"
 ron = "0.12.0"
 varisat = "0.2.2"
-version-ranges = { version = "0.1.0", path = "version-ranges", package = "astral-version-ranges", features = ["proptest"] }
+version-ranges = { version = "0.1.5", path = "version-ranges", package = "astral-version-ranges", features = ["proptest"] }
 
 [features]
 serde = ["dep:serde", "version-ranges/serde"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,9 +236,9 @@ pub use solver::{
 pub use term::Term;
 pub use type_aliases::{Map, Set};
 pub use version::{SemanticVersion, VersionParseError};
-pub use version_ranges::Ranges;
 #[deprecated(note = "Use `Ranges` instead")]
 pub use version_ranges::Ranges as Range;
+pub use version_ranges::{Ranges, SetRelation};
 pub use version_set::VersionSet;
 
 // uv-specific additions

--- a/src/term.rs
+++ b/src/term.rs
@@ -197,6 +197,8 @@ impl<VS: VersionSet> Term<VS> {
 
     /// Check if a set of terms satisfies or contradicts a given term.
     /// Otherwise the relation is inconclusive.
+    /// Satisfaction takes precedence when an empty positive intersection both satisfies and
+    /// contradicts the term.
     pub(crate) fn relation_with(&self, other_terms_intersection: &Self) -> Relation {
         match (self, other_terms_intersection) {
             (Self::Positive(range), Self::Positive(other)) => match other.relation(range) {
@@ -293,10 +295,6 @@ pub mod tests {
         fn is_disjoint(&self, _other: &Self) -> bool {
             panic!("subset-only term relations must not check disjointness")
         }
-
-        fn subset_of(&self, other: &Self) -> bool {
-            self.0.subset_of(&other.0)
-        }
     }
 
     pub fn strategy() -> impl Strategy<Value = Term<Ranges<u32>>> {
@@ -311,7 +309,7 @@ pub mod tests {
         let term = Term::Negative(Ranges::<u32>::singleton(1u32));
 
         assert!(matches!(
-            term.relation_with(&Term::Positive(Ranges::empty())),
+            term.relation_with(&Term::empty()),
             Relation::Satisfied
         ));
     }

--- a/src/term.rs
+++ b/src/term.rs
@@ -208,11 +208,17 @@ impl<VS: VersionSet> Term<VS> {
                 SetRelation::Subset => Relation::Contradicted,
                 SetRelation::Disjoint | SetRelation::Overlapping => Relation::Inconclusive,
             },
-            (Self::Negative(range), Self::Positive(other)) => match other.relation(range) {
-                SetRelation::Subset => Relation::Contradicted,
-                SetRelation::Disjoint => Relation::Satisfied,
-                SetRelation::Overlapping => Relation::Inconclusive,
-            },
+            (Self::Negative(range), Self::Positive(other)) => {
+                if other == &VS::empty() {
+                    Relation::Satisfied
+                } else {
+                    match other.relation(range) {
+                        SetRelation::Subset => Relation::Contradicted,
+                        SetRelation::Disjoint => Relation::Satisfied,
+                        SetRelation::Overlapping => Relation::Inconclusive,
+                    }
+                }
+            }
             (Self::Negative(range), Self::Negative(other)) => match range.relation(other) {
                 SetRelation::Subset => Relation::Satisfied,
                 SetRelation::Disjoint | SetRelation::Overlapping => Relation::Inconclusive,
@@ -252,6 +258,17 @@ pub mod tests {
             version_ranges::proptest_strategy().prop_map(Term::Positive),
         ]
     }
+
+    #[test]
+    fn empty_positive_intersection_satisfies_negative_term() {
+        let term = Term::Negative(Ranges::<u32>::singleton(1u32));
+
+        assert!(matches!(
+            term.relation_with(&Term::Positive(Ranges::empty())),
+            Relation::Satisfied
+        ));
+    }
+
     proptest! {
 
         // Testing relation --------------------------------

--- a/src/term.rs
+++ b/src/term.rs
@@ -204,10 +204,13 @@ impl<VS: VersionSet> Term<VS> {
                 SetRelation::Disjoint => Relation::Contradicted,
                 SetRelation::Overlapping => Relation::Inconclusive,
             },
-            (Self::Positive(range), Self::Negative(other)) => match range.relation(other) {
-                SetRelation::Subset => Relation::Contradicted,
-                SetRelation::Disjoint | SetRelation::Overlapping => Relation::Inconclusive,
-            },
+            (Self::Positive(range), Self::Negative(other)) => {
+                if range.subset_of(other) {
+                    Relation::Contradicted
+                } else {
+                    Relation::Inconclusive
+                }
+            }
             (Self::Negative(range), Self::Positive(other)) => {
                 if other == &VS::empty() {
                     Relation::Satisfied
@@ -219,10 +222,13 @@ impl<VS: VersionSet> Term<VS> {
                     }
                 }
             }
-            (Self::Negative(range), Self::Negative(other)) => match range.relation(other) {
-                SetRelation::Subset => Relation::Satisfied,
-                SetRelation::Disjoint | SetRelation::Overlapping => Relation::Inconclusive,
-            },
+            (Self::Negative(range), Self::Negative(other)) => {
+                if range.subset_of(other) {
+                    Relation::Satisfied
+                } else {
+                    Relation::Inconclusive
+                }
+            }
         }
     }
 }
@@ -252,6 +258,47 @@ pub mod tests {
     use proptest::prelude::*;
     use version_ranges::Ranges;
 
+    #[derive(Clone, Debug, Eq, Hash, PartialEq)]
+    struct NoDisjointRanges(Ranges<u32>);
+
+    impl Display for NoDisjointRanges {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            self.0.fmt(f)
+        }
+    }
+
+    impl VersionSet for NoDisjointRanges {
+        type V = u32;
+
+        fn empty() -> Self {
+            Self(Ranges::empty())
+        }
+
+        fn singleton(version: Self::V) -> Self {
+            Self(Ranges::singleton(version))
+        }
+
+        fn complement(&self) -> Self {
+            Self(self.0.complement())
+        }
+
+        fn intersection(&self, other: &Self) -> Self {
+            Self(self.0.intersection(&other.0))
+        }
+
+        fn contains(&self, version: &Self::V) -> bool {
+            self.0.contains(version)
+        }
+
+        fn is_disjoint(&self, _other: &Self) -> bool {
+            panic!("subset-only term relations must not check disjointness")
+        }
+
+        fn subset_of(&self, other: &Self) -> bool {
+            self.0.subset_of(&other.0)
+        }
+    }
+
     pub fn strategy() -> impl Strategy<Value = Term<Ranges<u32>>> {
         prop_oneof![
             version_ranges::proptest_strategy().prop_map(Term::Negative),
@@ -266,6 +313,21 @@ pub mod tests {
         assert!(matches!(
             term.relation_with(&Term::Positive(Ranges::empty())),
             Relation::Satisfied
+        ));
+    }
+
+    #[test]
+    fn subset_only_relations_do_not_check_disjointness() {
+        let one = NoDisjointRanges::singleton(1);
+        let two = NoDisjointRanges::singleton(2);
+
+        assert!(matches!(
+            Term::Positive(one.clone()).relation_with(&Term::Negative(two.clone())),
+            Relation::Inconclusive
+        ));
+        assert!(matches!(
+            Term::Negative(one).relation_with(&Term::Negative(two)),
+            Relation::Inconclusive
         ));
     }
 

--- a/src/term.rs
+++ b/src/term.rs
@@ -5,7 +5,7 @@
 
 use std::fmt::{self, Display};
 
-use crate::VersionSet;
+use crate::{SetRelation, VersionSet};
 
 /// A positive or negative expression regarding a set of versions.
 ///
@@ -140,6 +140,7 @@ impl<VS: VersionSet> Term<VS> {
     /// Indicate if this term is a subset of another term.
     /// Just like for sets, we say that t1 is a subset of t2
     /// if and only if t1 ∩ t2 = t1.
+    #[cfg(test)]
     pub(crate) fn subset_of(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::Positive(r1), Self::Positive(r2)) => r1.subset_of(r2),
@@ -197,12 +198,25 @@ impl<VS: VersionSet> Term<VS> {
     /// Check if a set of terms satisfies or contradicts a given term.
     /// Otherwise the relation is inconclusive.
     pub(crate) fn relation_with(&self, other_terms_intersection: &Self) -> Relation {
-        if other_terms_intersection.subset_of(self) {
-            Relation::Satisfied
-        } else if self.is_disjoint(other_terms_intersection) {
-            Relation::Contradicted
-        } else {
-            Relation::Inconclusive
+        match (self, other_terms_intersection) {
+            (Self::Positive(range), Self::Positive(other)) => match other.relation(range) {
+                SetRelation::Subset => Relation::Satisfied,
+                SetRelation::Disjoint => Relation::Contradicted,
+                SetRelation::Overlapping => Relation::Inconclusive,
+            },
+            (Self::Positive(range), Self::Negative(other)) => match range.relation(other) {
+                SetRelation::Subset => Relation::Contradicted,
+                SetRelation::Disjoint | SetRelation::Overlapping => Relation::Inconclusive,
+            },
+            (Self::Negative(range), Self::Positive(other)) => match other.relation(range) {
+                SetRelation::Subset => Relation::Contradicted,
+                SetRelation::Disjoint => Relation::Satisfied,
+                SetRelation::Overlapping => Relation::Inconclusive,
+            },
+            (Self::Negative(range), Self::Negative(other)) => match range.relation(other) {
+                SetRelation::Subset => Relation::Satisfied,
+                SetRelation::Disjoint | SetRelation::Overlapping => Relation::Inconclusive,
+            },
         }
     }
 }

--- a/src/version_set.rs
+++ b/src/version_set.rs
@@ -3,7 +3,7 @@
 use std::fmt::{Debug, Display};
 use std::hash::Hash;
 
-use crate::Ranges;
+use crate::{Ranges, SetRelation};
 
 /// A set of versions.
 ///
@@ -78,6 +78,21 @@ pub trait VersionSet: Debug + Display + Clone + Eq + Hash {
     fn subset_of(&self, other: &Self) -> bool {
         self == &self.intersection(other)
     }
+
+    /// Classifies `self` as a subset of, disjoint from, or partially overlapping with `other`.
+    ///
+    /// Implementations can override this to avoid traversing both sets once for [`Self::subset_of`]
+    /// and again for [`Self::is_disjoint`].
+    /// An empty `self` must be classified as [`SetRelation::Subset`].
+    fn relation(&self, other: &Self) -> SetRelation {
+        if self.subset_of(other) {
+            SetRelation::Subset
+        } else if self.is_disjoint(other) {
+            SetRelation::Disjoint
+        } else {
+            SetRelation::Overlapping
+        }
+    }
 }
 
 /// [`Ranges`] contains optimized implementations of all operations.
@@ -118,5 +133,9 @@ impl<T: Debug + Display + Clone + Eq + Ord + Hash> VersionSet for Ranges<T> {
 
     fn subset_of(&self, other: &Self) -> bool {
         Ranges::subset_of(self, other)
+    }
+
+    fn relation(&self, other: &Self) -> SetRelation {
+        Ranges::relation(self, other)
     }
 }

--- a/version-ranges/Cargo.toml
+++ b/version-ranges/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astral-version-ranges"
-version = "0.1.4"
+version = "0.1.5"
 description = "Performance-optimized type for generic version ranges and operations on them."
 edition = "2021"
 repository = "https://github.com/astral-sh/pubgrub"

--- a/version-ranges/Changelog.md
+++ b/version-ranges/Changelog.md
@@ -2,6 +2,10 @@
 
 Changelog for the version-ranges crate.
 
+## v0.1.5 - 2026-06-28
+
+- Add classification of subset, disjoint, and overlapping ranges.
+
 ## v0.1.3 - 2026-04-09
 
 - Add optional `semver` conversions ([#405](https://github.com/pubgrub-rs/pubgrub/pull/405))

--- a/version-ranges/src/lib.rs
+++ b/version-ranges/src/lib.rs
@@ -78,6 +78,20 @@ pub struct Ranges<V> {
     segments: SmallVec<[Interval<V>; 1]>,
 }
 
+/// Describes how one set relates to another.
+///
+/// [`SetRelation::Subset`] takes precedence when the left-hand set is empty and therefore also
+/// disjoint.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SetRelation {
+    /// Every value in the left-hand set is also in the right-hand set.
+    Subset,
+    /// The two sets have no values in common.
+    Disjoint,
+    /// The sets overlap, but the left-hand set is not a subset of the right-hand set.
+    Overlapping,
+}
+
 // TODO: Replace the tuple type with a custom enum inlining the bounds to reduce the type's size.
 type Interval<V> = (Bound<V>, Bound<V>);
 
@@ -734,6 +748,57 @@ impl<V: Ord + Clone> Ranges<V> {
         true
     }
 
+    /// Classifies `self` as a subset of, disjoint from, or partially overlapping with `other`.
+    ///
+    /// This combines [`Self::subset_of`] and [`Self::is_disjoint`] into a single traversal.
+    /// An empty `self` is classified as [`SetRelation::Subset`].
+    pub fn relation(&self, other: &Self) -> SetRelation {
+        // Equality is common for long accumulated ranges during PubGrub conflict resolution.
+        if self.segments.len() > 1
+            && self.segments.len() == other.segments.len()
+            && self.segments == other.segments
+        {
+            return SetRelation::Subset;
+        }
+
+        let mut other_iter = other.segments.iter().peekable();
+        let mut is_subset = true;
+        let mut overlaps = false;
+
+        for subset_elem in &self.segments {
+            while other_iter.peek().is_some_and(|containing_elem| {
+                !valid_segment(&subset_elem.start_bound(), &containing_elem.end_bound())
+            }) {
+                other_iter.next();
+            }
+
+            let Some(containing_elem) = other_iter.peek() else {
+                is_subset = false;
+                break;
+            };
+
+            if !valid_segment(&containing_elem.start_bound(), &subset_elem.end_bound()) {
+                is_subset = false;
+                continue;
+            }
+
+            overlaps = true;
+            if !left_start_is_smaller(containing_elem.start_bound(), subset_elem.start_bound())
+                || !left_end_is_smaller(subset_elem.end_bound(), containing_elem.end_bound())
+            {
+                is_subset = false;
+            }
+        }
+
+        if is_subset {
+            SetRelation::Subset
+        } else if overlaps {
+            SetRelation::Overlapping
+        } else {
+            SetRelation::Disjoint
+        }
+    }
+
     /// Return true if any `V` that is contained in `self` is also contained in `other`.
     ///
     /// Note that we don't know that set of all existing `V`s here, so we only check if all
@@ -1309,6 +1374,18 @@ pub mod tests {
         fn subset_of_through_intersection(r1 in proptest_strategy(), r2 in proptest_strategy()) {
             let disjoint_def = r1.intersection(&r2) == r1;
             assert_eq!(r1.subset_of(&r2), disjoint_def);
+        }
+
+        #[test]
+        fn relation_through_subset_and_disjoint(r1 in proptest_strategy(), r2 in proptest_strategy()) {
+            let relation_def = if r1.subset_of(&r2) {
+                SetRelation::Subset
+            } else if r1.is_disjoint(&r2) {
+                SetRelation::Disjoint
+            } else {
+                SetRelation::Overlapping
+            };
+            assert_eq!(r1.relation(&r2), relation_def);
         }
 
         #[test]


### PR DESCRIPTION
## Summary

PubGrub classifies term relationships by first checking whether the accumulated term is a subset of the incompatibility term and, when that fails, separately checking whether the terms are disjoint. For `Ranges`, those operations each traverse the segment lists, so relationships that need both answers can walk the same inputs twice during unit propagation.

This adds `SetRelation` and a default `VersionSet::relation` implementation, then gives `Ranges` a single traversal that reports subset, disjoint, or overlapping relationships. `Term::relation_with` uses the fused query for the two polarity combinations that need both subset and disjointness, while keeping subset-only combinations on `subset_of`. An empty positive intersection is handled separately to preserve the existing satisfaction-before-contradiction precedence, and custom version-set implementations retain the existing two-operation behavior through the default method.

Because `astral-pubgrub` now re-exports and calls the new API, this also bumps `astral-version-ranges` to 0.1.5 and raises PubGrub's dependency lower bound to that release. `astral-version-ranges` must be published before the next `astral-pubgrub` release.

## Performance

Alternating same-process A/B measurements against `0edce90`, followed by post-review checks against current `main`, produced:

| PubGrub benchmark | Result |
| --- | ---: |
| `backtracking_singletons` | 13.2%–17.1% faster across three runs |
| `backtracking_disjoint_versions` | no consistent change beyond local noise |
| `backtracking_ranges` | no consistent change beyond local noise |

The full all-features workspace test suite, relation property checks, focused regression tests, Clippy with warnings denied, formatting, and diff checks pass.
