### PR TITLE
Prepare pubgrub 0.5.0 and version-ranges 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## 0.5.0 - 2026-06-29
+
+### Breaking
+
+- `VersionSet` now requires `Hash`; `Ranges<V>` implements `VersionSet` only when `V: Hash` ([#65](https://github.com/astral-sh/pubgrub/pull/65)).
+- `Kind::FromDependencyOf` now stores only the dependent and dependency package IDs. Use `Incompatibility::dependency_version_sets()` to borrow their version sets ([#67](https://github.com/astral-sh/pubgrub/pull/67)).
+- Upgrade `astral-version-ranges` to 0.2.0, whose `Ranges::iter` now returns borrowed endpoints instead of references to stored bounds ([#30](https://github.com/astral-sh/pubgrub/pull/30)).
+
+### Added
+
+- Add `SetRelation` and `VersionSet::relation` for classifying two version sets in one pass ([#66](https://github.com/astral-sh/pubgrub/pull/66)).
+- Expose `DoubleEndedIterator` from `Ranges::iter` ([#62](https://github.com/astral-sh/pubgrub/pull/62)).
+
+### Changed
+
+- Reduce propagation and backtracking overhead with niche-optimized arena IDs and inline contradiction caching ([#58](https://github.com/astral-sh/pubgrub/pull/58), [#59](https://github.com/astral-sh/pubgrub/pull/59)).
+- Avoid repeated work when comparing and merging dependencies through equality shortcuts, hash-indexed candidates, and fused range relations ([#64](https://github.com/astral-sh/pubgrub/pull/64), [#65](https://github.com/astral-sh/pubgrub/pull/65), [#66](https://github.com/astral-sh/pubgrub/pull/66)).
+- Avoid cloning dependency version sets and reserve known arena batch capacity ([#67](https://github.com/astral-sh/pubgrub/pull/67), [#68](https://github.com/astral-sh/pubgrub/pull/68)).
+
 ## 0.4.0 - 2026-04-09
 
 ### Breaking

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "astral-pubgrub"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "astral-version-ranges",
  "cc",
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "astral-version-ranges"
-version = "0.1.5"
+version = "0.2.0"
 dependencies = [
  "proptest",
  "ron",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["version-ranges"]
 
 [package]
 name = "astral-pubgrub"
-version = "0.4.3"
+version = "0.5.0"
 authors = [
     "Matthieu Pizenberg <matthieu.pizenberg@gmail.com>",
     "Alex Tokarev <aleksator@gmail.com>",
@@ -35,7 +35,7 @@ priority-queue = "2.3.1"
 rustc-hash = "^2.1.1"
 serde = { version = "1.0.219", features = ["derive"], optional = true }
 thiserror = "2.0"
-version-ranges = { version = "0.1.5", package = "astral-version-ranges", path = "version-ranges" }
+version-ranges = { version = "0.2.0", package = "astral-version-ranges", path = "version-ranges" }
 
 [dev-dependencies]
 criterion = { version = "4.7.0", package = "codspeed-criterion-compat" }
@@ -45,7 +45,7 @@ cc = "1.2.40"
 proptest = "1.6.0"
 ron = "0.12.0"
 varisat = "0.2.2"
-version-ranges = { version = "0.1.5", path = "version-ranges", package = "astral-version-ranges", features = ["proptest"] }
+version-ranges = { version = "0.2.0", path = "version-ranges", package = "astral-version-ranges", features = ["proptest"] }
 
 [features]
 serde = ["dep:serde", "version-ranges/serde"]

--- a/version-ranges/Cargo.toml
+++ b/version-ranges/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astral-version-ranges"
-version = "0.1.5"
+version = "0.2.0"
 description = "Performance-optimized type for generic version ranges and operations on them."
 edition = "2021"
 repository = "https://github.com/astral-sh/pubgrub"

--- a/version-ranges/Changelog.md
+++ b/version-ranges/Changelog.md
@@ -2,9 +2,20 @@
 
 Changelog for the version-ranges crate.
 
-## v0.1.5 - 2026-06-28
+## v0.2.0 - 2026-06-29
 
-- Add classification of subset, disjoint, and overlapping ranges.
+### Breaking
+
+- `Ranges::iter` now returns `(Bound<&V>, Bound<&V>)`, consistent with `Ranges::bounding_range`, instead of references to stored `Bound<V>` values ([#30](https://github.com/astral-sh/pubgrub/pull/30)).
+
+### Added
+
+- Expose `DoubleEndedIterator` from `Ranges::iter` ([#62](https://github.com/astral-sh/pubgrub/pull/62)).
+- Add `SetRelation` and `Ranges::relation` for classifying two ranges as equal, subset, disjoint, or overlapping in one pass ([#66](https://github.com/astral-sh/pubgrub/pull/66)).
+
+### Changed
+
+- Short-circuit equality when checking multi-segment subset relationships ([#64](https://github.com/astral-sh/pubgrub/pull/64)).
 
 ## v0.1.3 - 2026-04-09
 


### PR DESCRIPTION
## Summary

Prepare `astral-version-ranges` 0.2.0 and `astral-pubgrub` 0.5.0 for publication.
