### PR TITLE
Fix version-ranges publish workflow

### DIFF
--- a/.github/workflows/publish-version-ranges.yml
+++ b/.github/workflows/publish-version-ranges.yml
@@ -16,7 +16,6 @@ jobs:
           persist-credentials: false
       - uses: rust-lang/crates-io-auth-action@b7e9a28eded4986ec6b1fa40eeee8f8f165559ec # v1
         id: auth
-        working-directory: version-ranges
       - run: cargo publish -p astral-version-ranges
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
## Summary

Remove the unsupported `working-directory` key from the crates.io authentication action in the version-ranges publishing workflow. GitHub only accepts that key for `run` steps, so the workflow currently fails during parsing and creates zero-job failed runs instead of waiting for a matching release tag.

The subsequent `cargo publish -p astral-version-ranges` command already selects the workspace package from the repository root. This restores the structure used by the last successful version-ranges publication so `version-ranges-v*` tag pushes can invoke the publish job again.
