### PR TITLE
Simplify version ranges during solving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Breaking
+
+- `State::add_package_version_dependencies` now takes the set of versions that share the dependencies. Pass `VS::singleton(version)` for the previous behavior. Callers that know which versions exist can instead widen the version being decided over the gaps to its neighboring versions (e.g. with `Ranges::widen_versions`), so rejecting versions one by one excludes contiguous sets instead of accumulating version sets with one hole per rejected version ([#73](https://github.com/astral-sh/pubgrub/pull/73)).
+
 ## 0.5.0 - 2026-06-29
 
 ### Breaking

--- a/src/internal/core.rs
+++ b/src/internal/core.rs
@@ -104,18 +104,38 @@ impl<DP: DependencyProvider> State<DP> {
         }
     }
 
-    /// Add the dependencies for the current version of the current package as incompatibilities.
+    /// Add the dependencies for the version being decided of the current package as
+    /// incompatibilities.
+    ///
+    /// `versions` is the set of versions that share these dependencies, in the simplest case the
+    /// version being decided: `VS::singleton(version)`. A caller that knows which versions exist
+    /// can widen the version being decided to a set that contains no other existing version,
+    /// e.g. with `Ranges::widen_versions`: If `2` is the only existing version between `1` and
+    /// `3`, the dependency incompatibilities for `{2}` can instead be created for `>1, <3`. When
+    /// resolution then rejects the version, the version sets derived from these
+    /// incompatibilities exclude a contiguous set instead of accumulating one hole per rejected
+    /// version, and the incompatibilities of adjacent versions merge into contiguous sets,
+    /// keeping the version sets and the operations on them minimal.
+    ///
+    /// `versions` must contain `version`, every existing version in `versions` must have exactly
+    /// the given dependencies, and the set of existing versions must not grow while resolution
+    /// is running.
     pub fn add_package_version_dependencies(
         &mut self,
         package: Id<DP::P>,
         version: DP::V,
+        versions: DP::VS,
         dependencies: impl IntoIterator<Item = (DP::P, DP::VS)>,
     ) -> Option<IncompId<DP::P, DP::VS, DP::M>> {
+        debug_assert!(
+            versions.contains(&version),
+            "the version being decided must be in the version set sharing its dependencies",
+        );
         let dep_incompats =
-            self.add_incompatibility_from_dependencies(package, version.clone(), dependencies);
+            self.add_incompatibility_from_dependencies(package, versions, dependencies);
         self.partial_solution.add_package_version_incompatibilities(
             package,
-            version.clone(),
+            version,
             dep_incompats,
             &self.incompatibility_store,
         )
@@ -168,7 +188,7 @@ impl<DP: DependencyProvider> State<DP> {
     pub(crate) fn add_incompatibility_from_dependencies(
         &mut self,
         package: Id<DP::P>,
-        version: DP::V,
+        versions: DP::VS,
         deps: impl IntoIterator<Item = (DP::P, DP::VS)>,
     ) -> std::ops::Range<IncompDpId<DP>> {
         // Create incompatibilities and allocate them in the store.
@@ -176,11 +196,7 @@ impl<DP: DependencyProvider> State<DP> {
             self.incompatibility_store
                 .alloc_iter(deps.into_iter().map(|(dep_p, dep_vs)| {
                     let dep_pid = self.package_store.alloc(dep_p);
-                    Incompatibility::from_dependency(
-                        package,
-                        <DP::VS as VersionSet>::singleton(version.clone()),
-                        (dep_pid, dep_vs),
-                    )
+                    Incompatibility::from_dependency(package, versions.clone(), (dep_pid, dep_vs))
                 }));
         // Merge the newly created incompatibilities with the older ones.
         for id in IncompDpId::<DP>::range_to_iter(new_incompats_id_range.clone()) {
@@ -492,7 +508,7 @@ mod dependency_merge_tests {
             let first = (version % 2) * 2;
             state.add_incompatibility_from_dependencies(
                 package,
-                version,
+                CollidingRanges::singleton(version),
                 [
                     ("dependency", CollidingRanges::singleton(first)),
                     ("dependency", CollidingRanges::singleton(first + 1)),

--- a/src/internal/incompatibility.rs
+++ b/src/internal/incompatibility.rs
@@ -760,6 +760,7 @@ pub(crate) mod tests {
             state.add_package_version_dependencies(
                 state.root_package,
                 0,
+                Ranges::singleton(0usize),
                 [("foo".to_string(), Ranges::singleton(1usize))],
             );
             state.unit_propagation(state.root_package).unwrap();
@@ -769,7 +770,12 @@ pub(crate) mod tests {
                 .partial_solution
                 .pick_highest_priority_pkg(|_p, _r| (0, Reverse(0)))
                 .unwrap();
-            state.add_package_version_dependencies(next, 1, case.clone());
+            state.add_package_version_dependencies(
+                next,
+                1,
+                Ranges::singleton(1usize),
+                case.clone(),
+            );
             state.unit_propagation(next).unwrap();
 
             assert!(

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -292,9 +292,12 @@ pub fn resolve<DP: DependencyProvider>(
             };
 
             // Add that package and version if the dependencies are not problematic.
-            if let Some(conflict) =
-                state.add_package_version_dependencies(p, v.clone(), dependencies)
-            {
+            if let Some(conflict) = state.add_package_version_dependencies(
+                p,
+                v.clone(),
+                <DP::VS as VersionSet>::singleton(v.clone()),
+                dependencies,
+            ) {
                 conflict_tracker.entry(p).or_default().dependencies_affected += 1;
                 for (incompat_package, _) in state.incompatibility_store[conflict].iter() {
                     if incompat_package == p {

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -292,12 +292,10 @@ pub fn resolve<DP: DependencyProvider>(
             };
 
             // Add that package and version if the dependencies are not problematic.
-            if let Some(conflict) = state.add_package_version_dependencies(
-                p,
-                v.clone(),
-                <DP::VS as VersionSet>::singleton(v.clone()),
-                dependencies,
-            ) {
+            let versions = <DP::VS as VersionSet>::singleton(v.clone());
+            if let Some(conflict) =
+                state.add_package_version_dependencies(p, v, versions, dependencies)
+            {
                 conflict_tracker.entry(p).or_default().dependencies_affected += 1;
                 for (incompat_package, _) in state.incompatibility_store[conflict].iter() {
                     if incompat_package == p {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -17,13 +17,14 @@ fn cloned_incompatibility_does_not_reuse_contradiction_cache() {
     base.add_package_version_dependencies(
         base.root_package,
         0,
+        Ranges::singleton(0u32),
         [("foo".to_string(), Ranges::full())],
     );
     base.unit_propagation(base.root_package).unwrap();
     let foo = base.package_store.alloc("foo".to_string());
 
     let mut source = base.clone();
-    source.add_package_version_dependencies(foo, 2, []);
+    source.add_package_version_dependencies(foo, 2, Ranges::singleton(2u32), []);
     source.add_incompatibility(Incompatibility::custom_version(
         foo,
         1,
@@ -34,7 +35,7 @@ fn cloned_incompatibility_does_not_reuse_contradiction_cache() {
     let incompatibility = source.incompatibility_store[incompatibility_id].clone();
 
     let mut target = base;
-    target.add_package_version_dependencies(foo, 1, []);
+    target.add_package_version_dependencies(foo, 1, Ranges::singleton(1u32), []);
     target.add_incompatibility(incompatibility);
 
     let conflicts = target.unit_propagation(foo).unwrap();

--- a/tests/widened_dependencies.rs
+++ b/tests/widened_dependencies.rs
@@ -29,7 +29,7 @@ fn resolve_with_widening(
         .packages()
         .map(|p| (*p, provider.versions(p).unwrap().copied().collect()))
         .collect();
-    let mut widened = 0u32;
+    let mut widened = false;
 
     let mut state: State<Provider> = State::init(root, version);
     let mut added_dependencies: Map<Id<&'static str>, BTreeSet<u32>> = Map::default();
@@ -81,15 +81,14 @@ fn resolve_with_widening(
                 }
                 Dependencies::Available(dependencies) => dependencies,
             };
+            let version_set = NumVS::singleton(decision);
             let versions = if widen {
-                let widened_versions = NumVS::singleton(decision)
-                    .widen_versions(versions.get(state.package_store[package]).unwrap());
-                if widened_versions != NumVS::singleton(decision) {
-                    widened += 1;
-                }
+                let widened_versions =
+                    version_set.widen_versions(versions.get(state.package_store[package]).unwrap());
+                widened |= widened_versions != version_set;
                 widened_versions
             } else {
-                NumVS::singleton(decision)
+                version_set
             };
             state.add_package_version_dependencies(package, decision, versions, dependencies);
         } else {
@@ -97,7 +96,7 @@ fn resolve_with_widening(
         }
     };
     if widen {
-        assert!(widened > 0, "no version set was ever widened");
+        assert!(widened, "no version set was ever widened");
     }
     Some(solution)
 }

--- a/tests/widened_dependencies.rs
+++ b/tests/widened_dependencies.rs
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! Resolution with dependent versions widened over the known versions must behave like
+//! resolution with singleton dependent versions.
+
+use std::collections::BTreeMap;
+use std::collections::BTreeSet;
+
+use pubgrub::{
+    Dependencies, DependencyProvider, Id, Incompatibility, Map, OfflineDependencyProvider,
+    PackageResolutionStatistics, Ranges, State, Term,
+};
+
+type NumVS = Ranges<u32>;
+type Provider = OfflineDependencyProvider<&'static str, NumVS>;
+
+/// A `resolve` loop that keeps the version sets minimal by widening the version whose
+/// dependencies are added over the known versions.
+///
+/// Returns `None` if there is no solution.
+fn resolve_with_widening(
+    provider: &Provider,
+    root: &'static str,
+    version: u32,
+    widen: bool,
+) -> Option<BTreeMap<&'static str, u32>> {
+    // Sorted version lists per package, the input for the widening.
+    let versions: Map<&'static str, Vec<u32>> = provider
+        .packages()
+        .map(|p| (*p, provider.versions(p).unwrap().copied().collect()))
+        .collect();
+    let mut widened = 0u32;
+
+    let mut state: State<Provider> = State::init(root, version);
+    let mut added_dependencies: Map<Id<&'static str>, BTreeSet<u32>> = Map::default();
+    let mut next = state.root_package;
+    let solution = loop {
+        state.unit_propagation(next).ok()?;
+
+        let Some((package, term_intersection)) =
+            state.partial_solution.pick_highest_priority_pkg(|p, r| {
+                provider.prioritize(
+                    &state.package_store[p],
+                    r,
+                    &PackageResolutionStatistics::default(),
+                )
+            })
+        else {
+            break state
+                .partial_solution
+                .extract_solution()
+                .map(|(p, v)| (state.package_store[p], v))
+                .collect();
+        };
+        next = package;
+
+        let Some(decision) = provider
+            .choose_version(&state.package_store[package], term_intersection)
+            .unwrap()
+        else {
+            let inc =
+                Incompatibility::no_versions(package, Term::Positive(term_intersection.clone()));
+            state.add_incompatibility(inc);
+            continue;
+        };
+
+        if added_dependencies
+            .entry(package)
+            .or_default()
+            .insert(decision)
+        {
+            let dependencies = match provider
+                .get_dependencies(&state.package_store[package], &decision)
+                .unwrap()
+            {
+                Dependencies::Unavailable(reason) => {
+                    state.add_incompatibility(Incompatibility::custom_version(
+                        package, decision, reason,
+                    ));
+                    continue;
+                }
+                Dependencies::Available(dependencies) => dependencies,
+            };
+            let versions = if widen {
+                let widened_versions = NumVS::singleton(decision)
+                    .widen_versions(versions.get(state.package_store[package]).unwrap());
+                if widened_versions != NumVS::singleton(decision) {
+                    widened += 1;
+                }
+                widened_versions
+            } else {
+                NumVS::singleton(decision)
+            };
+            state.add_package_version_dependencies(package, decision, versions, dependencies);
+        } else {
+            state.partial_solution.add_decision(package, decision);
+        }
+    };
+    if widen {
+        assert!(widened > 0, "no version set was ever widened");
+    }
+    Some(solution)
+}
+
+/// A registry that requires rejecting versions of "a" and "b" one by one, similar to boto3 and
+/// botocore: Without widening, the version sets of "a" accumulate one hole per rejected version,
+/// and the incompatibilities of "a" versions depending on "j" merge into growing unions of
+/// singletons.
+fn backtracking_provider(conflict_below: u32) -> Provider {
+    let mut provider = Provider::new();
+    provider.add_dependencies(
+        "root",
+        1u32,
+        [
+            ("u", Ranges::strictly_lower_than(2u32)),
+            ("a", Ranges::full()),
+        ],
+    );
+    provider.add_dependencies("u", 1u32, []);
+    provider.add_dependencies("u", 2u32, []);
+    for k in 1..=30u32 {
+        provider.add_dependencies("a", k, [("b", Ranges::singleton(k)), ("j", Ranges::full())]);
+        // Versions of "b" above the threshold conflict with the "u" requirement of root.
+        let u_range = if k >= conflict_below {
+            Ranges::higher_than(2u32)
+        } else {
+            Ranges::strictly_lower_than(2u32)
+        };
+        provider.add_dependencies("b", k, [("u", u_range)]);
+    }
+    provider.add_dependencies("j", 1u32, []);
+    provider
+}
+
+#[test]
+fn widening_finds_same_solution_after_backtracking() {
+    let provider = backtracking_provider(4);
+    let expected = BTreeMap::from([("root", 1), ("a", 3), ("b", 3), ("j", 1), ("u", 1)]);
+
+    let without = resolve_with_widening(&provider, "root", 1, false).unwrap();
+    let with = resolve_with_widening(&provider, "root", 1, true).unwrap();
+
+    assert_eq!(without, expected);
+    assert_eq!(with, expected);
+}
+
+#[test]
+fn widening_finds_same_conflict() {
+    // All versions of "b" conflict, so there is no solution.
+    let provider = backtracking_provider(0);
+
+    assert_eq!(resolve_with_widening(&provider, "root", 1, false), None);
+    assert_eq!(resolve_with_widening(&provider, "root", 1, true), None);
+}

--- a/version-ranges/Changelog.md
+++ b/version-ranges/Changelog.md
@@ -2,6 +2,12 @@
 
 Changelog for the version-ranges crate.
 
+## Unreleased
+
+### Added
+
+- Add `Ranges::widen_versions`, which widens each segment to the largest interval containing the same given versions and merges segments that no version separates ([#73](https://github.com/astral-sh/pubgrub/pull/73)).
+
 ## v0.2.0 - 2026-06-29
 
 ### Breaking

--- a/version-ranges/Changelog.md
+++ b/version-ranges/Changelog.md
@@ -7,6 +7,7 @@ Changelog for the version-ranges crate.
 ### Added
 
 - Add `Ranges::widen_versions`, which widens each segment to the largest interval containing the same given versions and merges segments that no version separates ([#73](https://github.com/astral-sh/pubgrub/pull/73)).
+- Add `Ranges::narrow_versions`, the display-oriented inverse of `Ranges::widen_versions`, which shrinks each segment to inclusive bounds on the given versions it contains ([#75](https://github.com/astral-sh/pubgrub/pull/75)).
 
 ## v0.2.0 - 2026-06-29
 

--- a/version-ranges/Changelog.md
+++ b/version-ranges/Changelog.md
@@ -7,7 +7,7 @@ Changelog for the version-ranges crate.
 ### Added
 
 - Add `Ranges::widen_versions`, which widens each segment to the largest interval containing the same given versions and merges segments that no version separates ([#73](https://github.com/astral-sh/pubgrub/pull/73)).
-- Add `Ranges::narrow_versions`, the display-oriented inverse of `Ranges::widen_versions`, which shrinks each segment to inclusive bounds on the given versions it contains ([#75](https://github.com/astral-sh/pubgrub/pull/75)).
+- Add `Ranges::narrow_versions`, the display-oriented inverse of `Ranges::widen_versions`, which shrinks each segment's bounded ends to inclusive bounds on the given versions it contains, keeping unbounded ends ([#75](https://github.com/astral-sh/pubgrub/pull/75)).
 
 ## v0.2.0 - 2026-06-29
 

--- a/version-ranges/src/lib.rs
+++ b/version-ranges/src/lib.rs
@@ -850,6 +850,57 @@ impl<V: Ord + Clone> Ranges<V> {
         true
     }
 
+    /// Returns a copy of this set where each segment is widened to the largest interval that
+    /// contains the same given versions, merging segments when no version separates them.
+    ///
+    /// A bound that excludes no existing version cannot influence which versions a set contains,
+    /// so each segment can extend outward up to, and excluding, the nearest version outside the
+    /// segment. For example, with the existing versions `1, 2, 3, 4`, the singleton `{2}` widens
+    /// to `(1, 3)`, and the union `{2} ∪ {3}` widens to `(1, ∞)`.
+    ///
+    /// The result is a superset of the input: For every one of the given versions, input and
+    /// output agree on whether it is contained, while versions not in `versions` may be added,
+    /// but are never removed.
+    ///
+    /// The `versions` slice must be sorted.
+    pub fn widen_versions<BV>(&self, versions: &[BV]) -> Self
+    where
+        BV: Borrow<V>,
+    {
+        debug_assert!(
+            versions.is_sorted_by(|l, r| l.borrow() <= r.borrow()),
+            "`widen_versions` `versions` argument incorrectly sorted"
+        );
+        let mut segments: SmallVec<[Interval<V>; 1]> = SmallVec::new();
+        for segment in &self.segments {
+            // The last version below the segment becomes the new exclusive start bound, the
+            // first version above the segment the new exclusive end bound.
+            let below =
+                versions.partition_point(|v| within_bounds(v.borrow(), segment) == Ordering::Less);
+            let start = if below == 0 {
+                Unbounded
+            } else {
+                Excluded(versions[below - 1].borrow().clone())
+            };
+            let not_above = versions
+                .partition_point(|v| within_bounds(v.borrow(), segment) != Ordering::Greater);
+            let end = if not_above == versions.len() {
+                Unbounded
+            } else {
+                Excluded(versions[not_above].borrow().clone())
+            };
+            // Merge with the previous segment unless a version separates them.
+            if let Some(last) = segments.last_mut() {
+                if !end_before_start_with_gap(&last.1, &start) {
+                    last.1 = end;
+                    continue;
+                }
+            }
+            segments.push((start, end));
+        }
+        Self { segments }.check_invariants()
+    }
+
     /// Returns a simpler representation that contains the same versions.
     ///
     /// For every one of the Versions provided in versions the existing range and the simplified range will agree on whether it is contained.
@@ -1463,6 +1514,20 @@ pub mod tests {
         }
 
         #[test]
+        fn widen_versions(range in proptest_strategy(), mut versions in proptest::collection::vec(version_strat(), ..30)) {
+            versions.sort();
+            let widened = range.widen_versions(&versions);
+
+            // The result is a superset of the input that agrees on all given versions.
+            assert!(range.subset_of(&widened));
+            for v in &versions {
+                assert_eq!(range.contains(v), widened.contains(v));
+            }
+            // The operation is idempotent.
+            assert_eq!(widened.widen_versions(&versions), widened);
+        }
+
+        #[test]
         fn from_iter_valid(segments in proptest::collection::vec(any::<(Bound<u32>, Bound<u32>)>(), ..30)) {
             let mut expected = Ranges::empty();
             for segment in &segments {
@@ -1500,6 +1565,34 @@ pub mod tests {
         let range: Ranges<String> = Ranges::singleton(1.to_string());
         let version = 1.to_string();
         assert_eq!(range.contains(&version), range.contains("1"));
+    }
+
+    #[test]
+    fn widen_versions_extends_to_neighboring_versions() {
+        let versions = [1u32, 2, 3, 5, 9];
+        // A singleton widens up to, and excluding, the neighboring versions.
+        assert_eq!(
+            Ranges::singleton(3u32).widen_versions(&versions),
+            Ranges::from_range_bounds((Excluded(2u32), Excluded(5u32)))
+        );
+        // Without a version above, the segment becomes unbounded.
+        assert_eq!(
+            Ranges::singleton(9u32).widen_versions(&versions),
+            Ranges::strictly_higher_than(5u32)
+        );
+        // The union of singletons of adjacent versions merges into a single segment.
+        let range: Ranges<u32> = Ranges::singleton(2u32).union(&Ranges::singleton(3u32));
+        assert_eq!(
+            range.widen_versions(&versions),
+            Ranges::from_range_bounds((Excluded(1u32), Excluded(5u32)))
+        );
+        // A version separating two segments is preserved.
+        let range: Ranges<u32> = Ranges::singleton(1u32).union(&Ranges::singleton(3u32));
+        assert_eq!(
+            range.widen_versions(&versions),
+            Ranges::strictly_lower_than(2u32)
+                .union(&Ranges::from_range_bounds((Excluded(2u32), Excluded(5u32))))
+        );
     }
 
     #[test]

--- a/version-ranges/src/lib.rs
+++ b/version-ranges/src/lib.rs
@@ -903,14 +903,16 @@ impl<V: Ord + Clone> Ranges<V> {
         Self { segments }.check_invariants()
     }
 
-    /// Returns a copy of this set where each segment is shrunk to the smallest interval that
-    /// contains the same given versions, with inclusive bounds on those versions.
+    /// Returns a copy of this set where each segment's bounded ends are shrunk to inclusive
+    /// bounds on the outermost given versions the segment contains.
     ///
     /// This is the display-oriented inverse of [`Ranges::widen_versions`]: bounds that exclude
     /// no existing version carry no information, so each segment can shrink to the first and
     /// last version it contains. For example, with the existing versions `1, 2, 3, 4`, the
-    /// segment `(1, 3)` shrinks to `{2}`, and `(1, ∞)` shrinks to `[2, 4]`. A segment that
-    /// contains none of the given versions is kept unchanged.
+    /// segment `(1, 3)` shrinks to `{2}`. Unbounded ends are kept, so a claim about all
+    /// versions beyond the given ones (e.g. versions not yet published) remains visible:
+    /// `(1, ∞)` shrinks to `[2, ∞)`, not `[2, 4]`. A segment that contains none of the given
+    /// versions is kept unchanged.
     ///
     /// The result is a subset of the input: For every one of the given versions, input and
     /// output agree on whether it is contained, while versions not in `versions` may be
@@ -936,10 +938,15 @@ impl<V: Ord + Clone> Ranges<V> {
                 // The segment contains none of the versions, keep it unchanged.
                 segments.push(segment.clone());
             } else {
-                segments.push((
-                    Included(versions[first].borrow().clone()),
-                    Included(versions[last - 1].borrow().clone()),
-                ));
+                let start = match &segment.0 {
+                    Unbounded => Unbounded,
+                    _ => Included(versions[first].borrow().clone()),
+                };
+                let end = match &segment.1 {
+                    Unbounded => Unbounded,
+                    _ => Included(versions[last - 1].borrow().clone()),
+                };
+                segments.push((start, end));
             }
         }
         Self { segments }.check_invariants()
@@ -1666,14 +1673,14 @@ pub mod tests {
             Ranges::from_range_bounds((Excluded(2u32), Excluded(5u32))).narrow_versions(&versions),
             Ranges::singleton(3u32)
         );
-        // An unbounded segment shrinks to the first and last contained version.
+        // Unbounded ends are kept, only the bounded end shrinks.
         assert_eq!(
             Ranges::strictly_higher_than(2u32).narrow_versions(&versions),
-            Ranges::from_range_bounds((Included(3u32), Included(9u32)))
+            Ranges::higher_than(3u32)
         );
         assert_eq!(
             Ranges::<u32>::full().narrow_versions(&versions),
-            Ranges::from_range_bounds((Included(1u32), Included(9u32)))
+            Ranges::full()
         );
         // A segment containing no version is kept unchanged.
         let range = Ranges::from_range_bounds((Excluded(5u32), Excluded(9u32)));

--- a/version-ranges/src/lib.rs
+++ b/version-ranges/src/lib.rs
@@ -884,8 +884,9 @@ impl<V: Ord + Clone> Ranges<V> {
             } else {
                 Excluded(versions[below - 1].borrow().clone())
             };
-            let not_above = versions
-                .partition_point(|v| within_bounds(v.borrow(), segment) != Ordering::Greater);
+            let not_above = below
+                + versions[below..]
+                    .partition_point(|v| within_bounds(v.borrow(), segment) != Ordering::Greater);
             let end = if not_above == versions.len() {
                 Unbounded
             } else {
@@ -929,8 +930,9 @@ impl<V: Ord + Clone> Ranges<V> {
             // The first and last version inside the segment become the new inclusive bounds.
             let first =
                 versions.partition_point(|v| within_bounds(v.borrow(), segment) == Ordering::Less);
-            let last = versions
-                .partition_point(|v| within_bounds(v.borrow(), segment) != Ordering::Greater);
+            let last = first
+                + versions[first..]
+                    .partition_point(|v| within_bounds(v.borrow(), segment) != Ordering::Greater);
             if first == last {
                 // The segment contains none of the versions, keep it unchanged.
                 segments.push(segment.clone());

--- a/version-ranges/src/lib.rs
+++ b/version-ranges/src/lib.rs
@@ -862,6 +862,8 @@ impl<V: Ord + Clone> Ranges<V> {
     /// output agree on whether it is contained, while versions not in `versions` may be added,
     /// but are never removed.
     ///
+    /// See [`Ranges::narrow_versions`] for the display-oriented inverse.
+    ///
     /// The `versions` slice must be sorted.
     pub fn widen_versions<BV>(&self, versions: &[BV]) -> Self
     where

--- a/version-ranges/src/lib.rs
+++ b/version-ranges/src/lib.rs
@@ -856,7 +856,7 @@ impl<V: Ord + Clone> Ranges<V> {
     /// A bound that excludes no existing version cannot influence which versions a set contains,
     /// so each segment can extend outward up to, and excluding, the nearest version outside the
     /// segment. For example, with the existing versions `1, 2, 3, 4`, the singleton `{2}` widens
-    /// to `(1, 3)`, and the union `{2} ∪ {3}` widens to `(1, ∞)`.
+    /// to `(1, 3)`, and the union `{2} ∪ {3}` widens to `(1, 4)`.
     ///
     /// The result is a superset of the input: For every one of the given versions, input and
     /// output agree on whether it is contained, while versions not in `versions` may be added,
@@ -892,13 +892,10 @@ impl<V: Ord + Clone> Ranges<V> {
                 Excluded(versions[not_above].borrow().clone())
             };
             // Merge with the previous segment unless a version separates them.
-            if let Some(last) = segments.last_mut() {
-                if !end_before_start_with_gap(&last.1, &start) {
-                    last.1 = end;
-                    continue;
-                }
+            match segments.last_mut() {
+                Some(last) if !end_before_start_with_gap(&last.1, &start) => last.1 = end,
+                _ => segments.push((start, end)),
             }
-            segments.push((start, end));
         }
         Self { segments }.check_invariants()
     }

--- a/version-ranges/src/lib.rs
+++ b/version-ranges/src/lib.rs
@@ -901,6 +901,48 @@ impl<V: Ord + Clone> Ranges<V> {
         Self { segments }.check_invariants()
     }
 
+    /// Returns a copy of this set where each segment is shrunk to the smallest interval that
+    /// contains the same given versions, with inclusive bounds on those versions.
+    ///
+    /// This is the display-oriented inverse of [`Ranges::widen_versions`]: bounds that exclude
+    /// no existing version carry no information, so each segment can shrink to the first and
+    /// last version it contains. For example, with the existing versions `1, 2, 3, 4`, the
+    /// segment `(1, 3)` shrinks to `{2}`, and `(1, ∞)` shrinks to `[2, 4]`. A segment that
+    /// contains none of the given versions is kept unchanged.
+    ///
+    /// The result is a subset of the input: For every one of the given versions, input and
+    /// output agree on whether it is contained, while versions not in `versions` may be
+    /// removed, but are never added.
+    ///
+    /// The `versions` slice must be sorted.
+    pub fn narrow_versions<BV>(&self, versions: &[BV]) -> Self
+    where
+        BV: Borrow<V>,
+    {
+        debug_assert!(
+            versions.is_sorted_by(|l, r| l.borrow() <= r.borrow()),
+            "`narrow_versions` `versions` argument incorrectly sorted"
+        );
+        let mut segments: SmallVec<[Interval<V>; 1]> = SmallVec::new();
+        for segment in &self.segments {
+            // The first and last version inside the segment become the new inclusive bounds.
+            let first =
+                versions.partition_point(|v| within_bounds(v.borrow(), segment) == Ordering::Less);
+            let last = versions
+                .partition_point(|v| within_bounds(v.borrow(), segment) != Ordering::Greater);
+            if first == last {
+                // The segment contains none of the versions, keep it unchanged.
+                segments.push(segment.clone());
+            } else {
+                segments.push((
+                    Included(versions[first].borrow().clone()),
+                    Included(versions[last - 1].borrow().clone()),
+                ));
+            }
+        }
+        Self { segments }.check_invariants()
+    }
+
     /// Returns a simpler representation that contains the same versions.
     ///
     /// For every one of the Versions provided in versions the existing range and the simplified range will agree on whether it is contained.
@@ -1528,6 +1570,25 @@ pub mod tests {
         }
 
         #[test]
+        fn narrow_versions(range in proptest_strategy(), mut versions in proptest::collection::vec(version_strat(), ..30)) {
+            versions.sort();
+            let narrowed = range.narrow_versions(&versions);
+
+            // The result is a subset of the input that agrees on all given versions.
+            assert!(narrowed.subset_of(&range));
+            for v in &versions {
+                assert_eq!(range.contains(v), narrowed.contains(v));
+            }
+            // The operation is idempotent.
+            assert_eq!(narrowed.narrow_versions(&versions), narrowed);
+            // Narrowing a widened set restores agreement on all given versions.
+            let round_trip = range.widen_versions(&versions).narrow_versions(&versions);
+            for v in &versions {
+                assert_eq!(range.contains(v), round_trip.contains(v));
+            }
+        }
+
+        #[test]
         fn from_iter_valid(segments in proptest::collection::vec(any::<(Bound<u32>, Bound<u32>)>(), ..30)) {
             let mut expected = Ranges::empty();
             for segment in &segments {
@@ -1593,6 +1654,28 @@ pub mod tests {
             Ranges::strictly_lower_than(2u32)
                 .union(&Ranges::from_range_bounds((Excluded(2u32), Excluded(5u32))))
         );
+    }
+
+    #[test]
+    fn narrow_versions_shrinks_to_contained_versions() {
+        let versions = [1u32, 2, 3, 5, 9];
+        // A segment shrinks to the versions it contains, with inclusive bounds.
+        assert_eq!(
+            Ranges::from_range_bounds((Excluded(2u32), Excluded(5u32))).narrow_versions(&versions),
+            Ranges::singleton(3u32)
+        );
+        // An unbounded segment shrinks to the first and last contained version.
+        assert_eq!(
+            Ranges::strictly_higher_than(2u32).narrow_versions(&versions),
+            Ranges::from_range_bounds((Included(3u32), Included(9u32)))
+        );
+        assert_eq!(
+            Ranges::<u32>::full().narrow_versions(&versions),
+            Ranges::from_range_bounds((Included(1u32), Included(9u32)))
+        );
+        // A segment containing no version is kept unchanged.
+        let range = Ranges::from_range_bounds((Excluded(5u32), Excluded(9u32)));
+        assert_eq!(range.narrow_versions(&versions), range);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

When dependency resolution rejects package versions one at a time, its version sets can accumulate a hole for every rejection. This PR lets callers widen a selected version across gaps between known versions when recording its dependencies, allowing adjacent incompatibilities to merge into contiguous ranges and keeping subsequent range operations small.

The built-in resolver preserves the existing singleton behavior; widening is opt-in for callers with a complete, fixed version list. `Ranges::narrow_versions` provides the display-oriented inverse for presenting widened ranges in terms of known versions without hiding unbounded coverage.
