### PR TITLE
Release pubgrub 0.6.1 and version-ranges 0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## 0.6.1 - 2026-08-07
 
 ### Added
 
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 
 ### Breaking
 
-- `State::add_package_version_dependencies` now takes the set of versions that share the dependencies. Pass `VS::singleton(version)` for the previous behavior. Callers that know which versions exist can instead widen the version being decided over the gaps to its neighboring versions (e.g. with `Ranges::widen_versions`), so rejecting versions one by one excludes contiguous sets instead of accumulating version sets with one hole per rejected version ([#73](https://github.com/astral-sh/pubgrub/pull/73)).
+- `State::add_package_version_dependencies` now takes the set of versions that share the dependencies. Pass `VS::singleton(version)` for the previous behavior. Callers that know which versions exist can instead widen the version being decided over the gaps to its neighboring versions (e.g. with `Ranges::widen_versions`), so rejecting versions one by one excludes contiguous sets instead of accumulating version sets with one hole per rejected version ([#75](https://github.com/astral-sh/pubgrub/pull/75)).
 
 ## 0.5.0 - 2026-06-29
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ dependencies = [
 
 [[package]]
 name = "astral-pubgrub"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "astral-version-ranges",
  "cc",
@@ -103,7 +103,7 @@ dependencies = [
 
 [[package]]
 name = "astral-version-ranges"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "proptest",
  "ron",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ members = ["version-ranges"]
 
 [package]
 name = "astral-pubgrub"
-version = "0.6.0"
+version = "0.6.1"
 authors = [
     "Matthieu Pizenberg <matthieu.pizenberg@gmail.com>",
     "Alex Tokarev <aleksator@gmail.com>",
@@ -35,7 +35,7 @@ priority-queue = "2.3.1"
 rustc-hash = "^2.1.1"
 serde = { version = "1.0.219", features = ["derive"], optional = true }
 thiserror = "2.0"
-version-ranges = { version = "0.2.1", package = "astral-version-ranges", path = "version-ranges" }
+version-ranges = { version = "0.2.2", package = "astral-version-ranges", path = "version-ranges" }
 
 [dev-dependencies]
 criterion = { version = "4.7.0", package = "codspeed-criterion-compat" }
@@ -45,7 +45,7 @@ cc = "1.2.40"
 proptest = "1.6.0"
 ron = "0.12.0"
 varisat = "0.2.2"
-version-ranges = { version = "0.2.1", path = "version-ranges", package = "astral-version-ranges", features = ["proptest"] }
+version-ranges = { version = "0.2.2", path = "version-ranges", package = "astral-version-ranges", features = ["proptest"] }
 
 [features]
 serde = ["dep:serde", "version-ranges/serde"]

--- a/version-ranges/Cargo.toml
+++ b/version-ranges/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astral-version-ranges"
-version = "0.2.1"
+version = "0.2.2"
 description = "Performance-optimized type for generic version ranges and operations on them."
 edition = "2021"
 repository = "https://github.com/astral-sh/pubgrub"

--- a/version-ranges/Changelog.md
+++ b/version-ranges/Changelog.md
@@ -2,7 +2,7 @@
 
 Changelog for the version-ranges crate.
 
-## Unreleased
+## v0.2.2 - 2026-08-07
 
 ### Added
 


### PR DESCRIPTION
Release astral-version-ranges 0.2.2 and astral-pubgrub 0.6.1.

Fixed a link in the 0.6.0 changelog too.